### PR TITLE
Add default permissions for operators and administrators #15

### DIFF
--- a/openwisp_firmware_upgrader/migrations/0002_default_permissions.py
+++ b/openwisp_firmware_upgrader/migrations/0002_default_permissions.py
@@ -1,0 +1,60 @@
+from django.db import migrations
+from django.contrib.auth.models import Permission
+
+from . import create_default_permissions
+
+
+
+def assign_permissions_to_groups(apps, schema_editor):
+    app_label = 'firmware_upgrader'
+    create_default_permissions(apps, schema_editor)
+    Group = apps.get_model('openwisp_users', 'Group')
+
+    try:
+        admin = Group.objects.get(name='Administrator')
+        operator = Group.objects.get(name='Operator')
+    # consider failures custom cases
+    # that do not have to be dealt with
+    except Group.DoesNotExist:
+        return
+
+    operators_read_only_admins_manage = ['build', 'devicefirmware', 'firmwareimage', 'batchupgradeoperation', 'upgradeoperation']
+    admins_can_manage = ['category']
+    manage_operations = ['add', 'change', 'delete']
+
+    for action in manage_operations:
+        for model_name in admins_can_manage:
+            permission = Permission.objects.get(
+                codename='{}_{}'.format(action, model_name),
+                content_type__app_label=app_label
+            )
+            admin.permissions.add(permission.pk)
+    for model_name in operators_read_only_admins_manage:
+        try:
+            permission = Permission.objects.get(
+                    codename='view_{}'.format(model_name),
+                    content_type__app_label=app_label
+            )
+            operator.permissions.add(permission.pk)
+        except Permission.DoesNotExist:
+            pass
+        for action in manage_operations:
+            permission_ad = Permission.objects.get(
+                    codename='{}_{}'.format(action, model_name),
+                    content_type__app_label=app_label
+            )
+            admin.permissions.add(permission_ad.pk)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('firmware_upgrader', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            assign_permissions_to_groups,
+            reverse_code=migrations.RunPython.noop
+        )
+    ]

--- a/openwisp_firmware_upgrader/migrations/__init__.py
+++ b/openwisp_firmware_upgrader/migrations/__init__.py
@@ -1,0 +1,8 @@
+from django.contrib.auth.management import create_permissions
+
+
+def create_default_permissions(apps, schema_editor):
+    for app_config in apps.get_app_configs():
+        app_config.models_module = True
+        create_permissions(app_config, apps=apps, verbosity=0)
+        app_config.models_module = None

--- a/tests/openwisp2/sample_firmware_upgrader/migrations/0002_default_permissions.py
+++ b/tests/openwisp2/sample_firmware_upgrader/migrations/0002_default_permissions.py
@@ -1,0 +1,60 @@
+from django.db import migrations
+from django.contrib.auth.models import Permission
+
+from . import create_default_permissions
+
+
+
+def assign_permissions_to_groups(apps, schema_editor):
+    app_label = 'sample_firmware_upgrader'
+    create_default_permissions(apps, schema_editor)
+    Group = apps.get_model('openwisp_users', 'Group')
+
+    try:
+        admin = Group.objects.get(name='Administrator')
+        operator = Group.objects.get(name='Operator')
+    # consider failures custom cases
+    # that do not have to be dealt with
+    except Group.DoesNotExist:
+        return
+
+    operators_read_only_admins_manage = ['build', 'devicefirmware', 'firmwareimage', 'batchupgradeoperation', 'upgradeoperation']
+    admins_can_manage = ['category']
+    manage_operations = ['add', 'change', 'delete']
+
+    for action in manage_operations:
+        for model_name in admins_can_manage:
+            permission = Permission.objects.get(
+                codename='{}_{}'.format(action, model_name),
+                content_type__app_label=app_label
+            )
+            admin.permissions.add(permission.pk)
+    for model_name in operators_read_only_admins_manage:
+        try:
+            permission = Permission.objects.get(
+                    codename='view_{}'.format(model_name),
+                    content_type__app_label=app_label
+            )
+            operator.permissions.add(permission.pk)
+        except Permission.DoesNotExist:
+            pass
+        for action in manage_operations:
+            permission_ad = Permission.objects.get(
+                    codename='{}_{}'.format(action, model_name),
+                    content_type__app_label=app_label
+            )
+            admin.permissions.add(permission_ad.pk)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sample_firmware_upgrader', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            assign_permissions_to_groups,
+            reverse_code=migrations.RunPython.noop
+        )
+    ]

--- a/tests/openwisp2/sample_firmware_upgrader/migrations/__init__.py
+++ b/tests/openwisp2/sample_firmware_upgrader/migrations/__init__.py
@@ -1,0 +1,8 @@
+from django.contrib.auth.management import create_permissions
+
+
+def create_default_permissions(apps, schema_editor):
+    for app_config in apps.get_app_configs():
+        app_config.models_module = True
+        create_permissions(app_config, apps=apps, verbosity=0)
+        app_config.models_module = None


### PR DESCRIPTION
Operators can:

* view builds and related images
* view mass upgrade operations and related device operations
* view device firmware objects

Administrators can:
* all permission on all objects

Closes #15