### PR TITLE
[fw-upgrade] Fix invalid multitenant_shared_relations for DeviceFirmware

### DIFF
--- a/openwisp_firmware_upgrader/base/admin.py
+++ b/openwisp_firmware_upgrader/base/admin.py
@@ -193,7 +193,7 @@ class DeviceFirmwareInline(MultitenantAdminMixin, admin.StackedInline):
     verbose_name = _('Device Firmware')
     verbose_name_plural = verbose_name
     extra = 0
-    multitenant_shared_relations = ('image',)
+    multitenant_shared_relations = ('device',)
 
     def has_add_permission(self, request, obj=None):
         return obj and not obj._state.adding

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -57,11 +57,11 @@ INSTALLED_APPS = [
     'channels',
 ]
 
-EXTENDED_APPS = (
+EXTENDED_APPS = [
     'django_netjsonconfig',
     'django_x509',
     'django_loci',
-)
+]
 
 AUTH_USER_MODEL = 'openwisp_users.User'
 SITE_ID = '1'
@@ -185,7 +185,7 @@ OPENWISP_CUSTOM_OPENWRT_IMAGES = (
 
 if os.environ.get('SAMPLE_APP', False):
     INSTALLED_APPS.remove('openwisp_firmware_upgrader')
-    EXTENDED_APPS = ['openwisp_firmware_upgrader']
+    EXTENDED_APPS.append('openwisp_firmware_upgrader')
     INSTALLED_APPS.append('openwisp2.sample_firmware_upgrader')
     FIRMWARE_UPGRADER_CATEGORY_MODEL = 'sample_firmware_upgrader.Category'
     FIRMWARE_UPGRADER_BUILD_MODEL = 'sample_firmware_upgrader.Build'


### PR DESCRIPTION
This was causing a 500 internal server error for non-admin users, which
could not edit nor view Devices in the admin dashboard.

Fixes #16