### PR TITLE
[ci] Run sample app tests in same build to reduce build time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,8 @@ before_install:
 
 install:
   - pip install -e .
+  # temporary: remove when openwisp-utils 0.5.0 is released
+  - pip install -U https://github.com/openwisp/openwisp-utils/tarball/master#egg=openwisp_utils[qa]
 
 script:
   - SAMPLE_APP=1; coverage run --source=openwisp_firmware_upgrader runtests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,6 @@ python:
 env:
   - DJANGO="django>=2.2,<2.3"
   - DJANGO="django>=3.0,<3.1"
-  - SAMPLE_APP=1 DJANGO="django>=2.2,<2.3"
-  - SAMPLE_APP=1 DJANGO="django>=3.0,<3.1"
 
 branches:
   only:
@@ -31,13 +29,14 @@ branches:
 
 before_install:
   - pip install -U pip wheel setuptools
-  - pip install --no-cache-dir -U -r requirements-test.txt
+  - pip install $DJANGO
+  - pip install -U -r requirements-test.txt
 
 install:
-  - pip install $DJANGO
   - pip install -e .
 
 script:
+  - SAMPLE_APP=1; coverage run --source=openwisp_firmware_upgrader runtests.py
   - coverage run --source=openwisp_firmware_upgrader runtests.py
   - ./run-qa-checks
 

--- a/openwisp_firmware_upgrader/tests/base/test_admin.py
+++ b/openwisp_firmware_upgrader/tests/base/test_admin.py
@@ -9,7 +9,6 @@ User = get_user_model()
 
 
 class BaseTestAdmin(TestMultitenantAdminMixin):
-
     def test_build_list(self):
         self._login()
         build = self._create_build()

--- a/run-qa-checks
+++ b/run-qa-checks
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 openwisp-utils-qa-checks \
     --migration-path ./openwisp_firmware_upgrader/migrations \
     --migration-module firmware_upgrader

--- a/run-qa-checks
+++ b/run-qa-checks
@@ -1,16 +1,17 @@
 #!/bin/bash
 set -e
-openwisp-utils-qa-checks \
+openwisp-qa-check \
     --migration-path ./openwisp_firmware_upgrader/migrations \
     --migration-module firmware_upgrader
 
-export SAMPLE_APP=1
-openwisp-utils-qa-checks \
+echo ''
+echo 'Running checks for SAMPLE_APP'
+SAMPLE_APP=1 openwisp-qa-check \
     --skip-isort \
     --skip-flake8 \
     --skip-checkmigrations \
     --skip-checkendline \
     --skip-checkcommit \
+    --skip-black \
     --migration-path ./tests/openwisp2/sample_firmware_upgrader/migrations/ \
     --migration-module sample_firmware_upgrader
-unset SAMPLE_APP


### PR DESCRIPTION
I'm testing this change to save build time since creating a new container and installing all the packages requires time and resources on the side of travis. We'll just have to double check:

1. sample app tests are run as expected
2. coverage is not affected and works properly

@atb00ker @nepython @PabloCastellano @NoumbissiValere @TheOneAboveAllTitan please check this out before it will affect part of your work.

If this approach work we should adopt it on all the modules.