### PR TITLE
[api] Add ScopedRateThrottling by default #48

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
   # temporary: remove when openwisp-controller 0.7.0 is released
   - pip install -U https://github.com/openwisp/openwisp-controller/tarball/master
   # temporary: remove when openwisp-utils 0.5.0 is released
-  - pip install -U https://github.com/openwisp/openwisp-utils/tarball/master#egg=openwisp_utils[qa,rest]
+  - pip install -U https://github.com/openwisp/openwisp-utils/tarball/api-scopedratethrottle#egg=openwisp_utils[qa,rest]
   # temporary: remove when openwisp-users with API support is released
   - pip install -U https://github.com/openwisp/openwisp-users/tarball/master#egg=openwisp_users[rest]
   - pip install -e .

--- a/openwisp_firmware_upgrader/api/views.py
+++ b/openwisp_firmware_upgrader/api/views.py
@@ -28,6 +28,7 @@ FirmwareImage = load_model('FirmwareImage')
 class ProtectedAPIMixin(object):
     authentication_classes = [BearerAuthentication, SessionAuthentication]
     permission_classes = [DjangoModelPermissions]
+    throttle_scope = 'firmware_upgrader'
 
 
 class OrgAPIMixin(ProtectedAPIMixin):

--- a/openwisp_firmware_upgrader/apps.py
+++ b/openwisp_firmware_upgrader/apps.py
@@ -10,6 +10,7 @@ class FirmwareUpdaterConfig(AppConfig):
 
     def ready(self, *args, **kwargs):
         self.add_default_menu_items()
+        self.configure_drf_defaults()
 
     def add_default_menu_items(self):
         menu_setting = 'OPENWISP_DEFAULT_ADMIN_MENU_ITEMS'
@@ -21,3 +22,9 @@ class FirmwareUpdaterConfig(AppConfig):
         else:
             current_menu = getattr(settings, menu_setting)
             current_menu += items
+
+    def configure_drf_defaults(self):
+        config = getattr(settings, 'REST_FRAMEWORK', {})
+        config.setdefault('DEFAULT_THROTTLE_RATES', {})
+        config['DEFAULT_THROTTLE_RATES'].setdefault('firmware_upgrader', '400/hour')
+        setattr(settings, 'REST_FRAMEWORK', config)

--- a/openwisp_firmware_upgrader/tests/test_api.py
+++ b/openwisp_firmware_upgrader/tests/test_api.py
@@ -1,5 +1,6 @@
 import uuid
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import Client, TestCase
 from django.urls import reverse
@@ -25,6 +26,9 @@ FirmwareImage = load_model('FirmwareImage')
 UpgradeOperation = load_model('UpgradeOperation')
 
 user_model = get_user_model()
+
+# Disable default rate limit
+setattr(settings, 'REST_FRAMEWORK', {})
 
 
 class TestAPIUpgraderMixin(TestMultitenantAdminMixin, TestUpgraderMixin):

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     'django_extensions',
     'private_storage',
     # openwisp2 modules
+    'openwisp_utils',
     'openwisp_users',
     'openwisp_controller.pki',
     'openwisp_controller.config',


### PR DESCRIPTION
Requires https://github.com/openwisp/openwisp-utils/pull/112

Note that by using ScopedRateThrottling it requires us to define a default anon class throttle for the unauthenticated API requests.

Closes #48