### PR TITLE
[api] Add pagination #79

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -316,6 +316,17 @@ When browsing the API via the `Live documentation <#live-documentation>`_
 or the `Browsable web page <#browsable-web-interface>`_, you can also use
 the session authentication by logging in the django admin.
 
+Pagination
+~~~~~~~~~~
+
+All *list* endpoints support the ``page_size`` parameter that allows paginating
+the results in conjunction with the ``page`` parameter.
+
+.. code-block:: text
+
+    GET /api/v1/firmware/build/?page_size=10
+    GET /api/v1/firmware/build/?page_size=10&page=2
+
 List of endpoints
 ~~~~~~~~~~~~~~~~~
 

--- a/openwisp_firmware_upgrader/api/views.py
+++ b/openwisp_firmware_upgrader/api/views.py
@@ -3,7 +3,7 @@ from wsgiref.util import FileWrapper
 from django.core.exceptions import ValidationError
 from django.http import HttpResponse
 from django_filters.rest_framework import DjangoFilterBackend
-from rest_framework import filters, generics
+from rest_framework import filters, generics, pagination
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.exceptions import NotFound
 from rest_framework.permissions import DjangoModelPermissions
@@ -25,10 +25,17 @@ Category = load_model('Category')
 FirmwareImage = load_model('FirmwareImage')
 
 
+class ListViewPagination(pagination.PageNumberPagination):
+    page_size = 10
+    page_size_query_param = 'page_size'
+    max_page_size = 100
+
+
 class ProtectedAPIMixin(object):
     authentication_classes = [BearerAuthentication, SessionAuthentication]
     permission_classes = [DjangoModelPermissions]
     throttle_scope = 'firmware_upgrader'
+    pagination_class = ListViewPagination
 
 
 class OrgAPIMixin(ProtectedAPIMixin):

--- a/openwisp_firmware_upgrader/tests/test_api.py
+++ b/openwisp_firmware_upgrader/tests/test_api.py
@@ -76,9 +76,9 @@ class TestBuildViews(TestAPIUpgraderMixin, TestCase):
             for build in Build.objects.all().order_by('-created')
         ]
         url = reverse('upgrader:api_build_list')
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(3):
             r = self.client.get(url)
-        self.assertEqual(r.data, serialized_list)
+        self.assertEqual(r.data['results'], serialized_list)
 
     def test_build_list_django_filters(self):
         category1 = self._create_category()
@@ -89,14 +89,14 @@ class TestBuildViews(TestAPIUpgraderMixin, TestCase):
         url = reverse('upgrader:api_build_list')
 
         filter_params = dict(category=category1.pk)
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4):
             r = self.client.get(url, filter_params)
-        self.assertEqual(r.data, [self._serialize_build(build1)])
+        self.assertEqual(r.data['results'], [self._serialize_build(build1)])
 
         filter_params = dict(category=category2.pk)
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4):
             r = self.client.get(url, filter_params)
-        self.assertEqual(r.data, [self._serialize_build(build2)])
+        self.assertEqual(r.data['results'], [self._serialize_build(build2)])
 
     def test_build_list_filter_org(self):
         org2 = self._create_org(name='New org', slug='new-org')
@@ -114,17 +114,17 @@ class TestBuildViews(TestAPIUpgraderMixin, TestCase):
         serialized_list = [
             self._serialize_build(build),
         ]
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(3):
             r = self.client.get(url)
-        self.assertEqual(r.data, serialized_list)
+        self.assertEqual(r.data['results'], serialized_list)
 
         self._login('operator2', 'tester')
         serialized_list = [
             self._serialize_build(build2),
         ]
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(3):
             r = self.client.get(url)
-        self.assertEqual(r.data, serialized_list)
+        self.assertEqual(r.data['results'], serialized_list)
 
     def test_build_list_filter_org_admin(self):
         org2 = self._create_org(name='New org', slug='new-org')
@@ -143,17 +143,17 @@ class TestBuildViews(TestAPIUpgraderMixin, TestCase):
             self._serialize_build(build)
             for build in Build.objects.all().order_by('-created')
         ]
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(3):
             r = self.client.get(url)
-        self.assertEqual(r.data, serialized_list)
+        self.assertEqual(r.data['results'], serialized_list)
 
         data_filter = {'org': 'New org'}
         serialized_list = [
             self._serialize_build(build2),
         ]
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(3):
             r = self.client.get(url, data_filter)
-        self.assertEqual(r.data, serialized_list)
+        self.assertEqual(r.data['results'], serialized_list)
 
     def test_build_list_filter_html(self):
         self._create_build(organization=self.org)
@@ -256,9 +256,9 @@ class TestCategoryViews(TestAPIUpgraderMixin, TestCase):
             for category in Category.objects.all().order_by('-name')
         ]
         url = reverse('upgrader:api_category_list')
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(3):
             r = self.client.get(url)
-        self.assertEqual(r.data, serialized_list)
+        self.assertEqual(r.data['results'], serialized_list)
 
     def test_category_list_filter_org(self):
         org2 = self._create_org(name='New org', slug='new-org')
@@ -275,17 +275,17 @@ class TestCategoryViews(TestAPIUpgraderMixin, TestCase):
         serialized_list = [
             self._serialize_category(category),
         ]
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(3):
             r = self.client.get(url)
-        self.assertEqual(r.data, serialized_list)
+        self.assertEqual(r.data['results'], serialized_list)
 
         self._login('operator2', 'tester')
         serialized_list = [
             self._serialize_category(category2),
         ]
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(3):
             r = self.client.get(url)
-        self.assertEqual(r.data, serialized_list)
+        self.assertEqual(r.data['results'], serialized_list)
 
     def test_category_list_filter_org_admin(self):
         org2 = self._create_org(name='New org', slug='new-org')
@@ -303,17 +303,17 @@ class TestCategoryViews(TestAPIUpgraderMixin, TestCase):
             self._serialize_category(category)
             for category in Category.objects.all().order_by('-name')
         ]
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(3):
             r = self.client.get(url)
-        self.assertEqual(r.data, serialized_list)
+        self.assertEqual(r.data['results'], serialized_list)
 
         data_filter = {'org': 'New org'}
         serialized_list = [
             self._serialize_category(category2),
         ]
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(3):
             r = self.client.get(url, data_filter)
-        self.assertEqual(r.data, serialized_list)
+        self.assertEqual(r.data['results'], serialized_list)
 
     def test_category_create(self):
         url = reverse('upgrader:api_category_list')
@@ -410,9 +410,9 @@ class TestBatchUpgradeOperationViews(TestAPIUpgraderMixin, TestCase):
         operation = BatchUpgradeOperation.objects.get(build=env['build2'])
         serialized_list = [self._serialize_upgrade_env(operation)]
         url = reverse('upgrader:api_batchupgradeoperation_list')
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(3):
             r = self.client.get(url)
-        self.assertEqual(r.data, serialized_list)
+        self.assertEqual(r.data['results'], serialized_list)
 
     def test_batchupgradeoperation_list_django_filters(self):
         env = self._create_upgrade_env(organization=self.org)
@@ -425,23 +425,23 @@ class TestBatchUpgradeOperationViews(TestAPIUpgraderMixin, TestCase):
             self._serialize_upgrade_env(operation)
             for operation in BatchUpgradeOperation.objects.order_by('-created')
         ]
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(3):
             r = self.client.get(url)
-        self.assertEqual(r.data, serialized_list)
+        self.assertEqual(r.data['results'], serialized_list)
 
         operation = BatchUpgradeOperation.objects.get(build=env['build1'])
         serialized_list = [self._serialize_upgrade_env(operation)]
         filter_params = dict(build=env['build1'].pk)
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4):
             r = self.client.get(url, filter_params)
-        self.assertEqual(r.data, serialized_list)
+        self.assertEqual(r.data['results'], serialized_list)
 
         operation = BatchUpgradeOperation.objects.get(build=env['build2'])
         serialized_list = [self._serialize_upgrade_env(operation)]
         filter_params = dict(build=env['build2'].pk)
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4):
             r = self.client.get(url, filter_params)
-        self.assertEqual(r.data, serialized_list)
+        self.assertEqual(r.data['results'], serialized_list)
 
         serialized_list = [
             self._serialize_upgrade_env(operation)
@@ -452,7 +452,7 @@ class TestBatchUpgradeOperationViews(TestAPIUpgraderMixin, TestCase):
         filter_params = dict(status='in-progress')
         with self.assertNumQueries(2):
             r = self.client.get(url, filter_params)
-        self.assertEqual(r.data, serialized_list)
+        self.assertEqual(r.data['results'], serialized_list)
 
         serialized_list = [
             self._serialize_upgrade_env(operation)
@@ -463,7 +463,7 @@ class TestBatchUpgradeOperationViews(TestAPIUpgraderMixin, TestCase):
         filter_params = dict(status='success')
         with self.assertNumQueries(2):
             r = self.client.get(url, filter_params)
-        self.assertEqual(r.data, serialized_list)
+        self.assertEqual(r.data['results'], serialized_list)
 
     def test_batchupgradeoperation_list_filter_org(self):
         org2 = self._create_org(name='New org', slug='new-org')
@@ -482,16 +482,16 @@ class TestBatchUpgradeOperationViews(TestAPIUpgraderMixin, TestCase):
         self._login('operator', 'tester')
         operation = BatchUpgradeOperation.objects.get(build=env['build2'])
         serialized_list = [self._serialize_upgrade_env(operation)]
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(3):
             r = self.client.get(url)
-        self.assertEqual(r.data, serialized_list)
+        self.assertEqual(r.data['results'], serialized_list)
 
         self._login('operator2', 'tester')
         operation2 = BatchUpgradeOperation.objects.get(build=env2['build2'])
         serialized_list = [self._serialize_upgrade_env(operation2)]
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(3):
             r = self.client.get(url)
-        self.assertEqual(r.data, serialized_list)
+        self.assertEqual(r.data['results'], serialized_list)
 
     def test_batchupgradeoperation_list_filter_org_admin(self):
         org2 = self._create_org(name='New org', slug='new-org')
@@ -516,15 +516,15 @@ class TestBatchUpgradeOperationViews(TestAPIUpgraderMixin, TestCase):
             self._serialize_upgrade_env(operation)
             for operation in BatchUpgradeOperation.objects.all().order_by('-created')
         ]
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(3):
             r = self.client.get(url)
-        self.assertEqual(r.data, serialized_list)
+        self.assertEqual(r.data['results'], serialized_list)
 
         data_filter = {'org': 'New org'}
         serialized_list = [self._serialize_upgrade_env(operation2)]
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(3):
             r = self.client.get(url, data_filter)
-        self.assertEqual(r.data, serialized_list)
+        self.assertEqual(r.data['results'], serialized_list)
 
     def test_batchupgradeoperation_view(self):
         env = self._create_upgrade_env()
@@ -577,9 +577,9 @@ class TestFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
             for image in FirmwareImage.objects.all().order_by('-created')
         ]
         url = reverse('upgrader:api_firmware_list', args=[image.build.pk])
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4):
             r = self.client.get(url)
-        self.assertEqual(r.data, serialized_list)
+        self.assertEqual(r.data['results'], serialized_list)
 
     def test_firmware_list_404(self):
         for pk in ['123456', uuid.uuid4()]:
@@ -595,16 +595,16 @@ class TestFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
         url = reverse('upgrader:api_firmware_list', args=[image.build.pk])
 
         filter_params = dict(type=self.TPLINK_4300_IMAGE)
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4):
             r = self.client.get(url, filter_params)
-        self.assertEqual(r.data, [self._serialize_image(image)])
+        self.assertEqual(r.data['results'], [self._serialize_image(image)])
 
         url = reverse('upgrader:api_firmware_list', args=[image.build.pk])
 
         filter_params = dict(type=self.TPLINK_4300_IL_IMAGE)
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4):
             r = self.client.get(url, filter_params)
-        self.assertEqual(r.data, [self._serialize_image(image2)])
+        self.assertEqual(r.data['results'], [self._serialize_image(image2)])
 
     def test_firmware_list_filter_org(self):
         org2 = self._create_org(name='New org', slug='new-org')
@@ -621,16 +621,16 @@ class TestFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
 
         self._login('operator', 'tester')
         serialized_list = [self._serialize_image(image)]
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4):
             r = self.client.get(url)
-        self.assertEqual(r.data, serialized_list)
+        self.assertEqual(r.data['results'], serialized_list)
 
         url = reverse('upgrader:api_firmware_list', args=[image2.build.pk])
         self._login('operator2', 'tester')
         serialized_list = [self._serialize_image(image2)]
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4):
             r = self.client.get(url)
-        self.assertEqual(r.data, serialized_list)
+        self.assertEqual(r.data['results'], serialized_list)
 
     def test_firmware_list_filter_org_admin(self):
         org2 = self._create_org(name='New org', slug='new-org')
@@ -650,17 +650,17 @@ class TestFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
             self._serialize_image(image),
         ]
 
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4):
             r = self.client.get(url)
-        self.assertEqual(r.data, serialized_list)
+        self.assertEqual(r.data['results'], serialized_list)
 
         url = reverse('upgrader:api_firmware_list', args=[image2.build.pk])
 
         data_filter = {'org': 'New org'}
         serialized_list = [self._serialize_image(image2)]
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4):
             r = self.client.get(url, data_filter)
-        self.assertEqual(r.data, serialized_list)
+        self.assertEqual(r.data['results'], serialized_list)
 
     def test_firmware_create(self):
         build = self._create_build()
@@ -758,7 +758,7 @@ class TestOrgAPIMixin(TestAPIUpgraderMixin, TestCase):
             self._serialize_build(build)
             for build in Build.objects.all().order_by('-created')
         ]
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(3):
             r = self.client.get(url)
-        self.assertEqual(r.data, serialized_list)
+        self.assertEqual(r.data['results'], serialized_list)
         self.assertEqual(r.status_code, 200)


### PR DESCRIPTION
Notes:

* json output has changed, now results are now returned in the 'results' key of the dictionary
* An extra sql query is required to count the total number of results

Closes #79