### PR TITLE
[fw-upgrade] Add button to launch mass upgrade in Build #25

### DIFF
--- a/openwisp_firmware_upgrader/static/admin/css/firmware-upgrader.css
+++ b/openwisp_firmware_upgrader/static/admin/css/firmware-upgrader.css
@@ -1,0 +1,11 @@
+input.object-tools-button {
+    padding: 5px 15px;
+    background-color: #999;
+    font-weight: 400;
+    font-size: 13px;
+    line-height: 20px;
+    margin: 0;
+    display: block;
+    float: left;
+    border-radius: 15px;
+}

--- a/openwisp_firmware_upgrader/templates/admin/firmware_upgrader/change_form.html
+++ b/openwisp_firmware_upgrader/templates/admin/firmware_upgrader/change_form.html
@@ -1,0 +1,17 @@
+{% extends "admin/change_form.html" %}
+{% load i18n admin_modify %}
+
+{% block object-tools-items %}
+{% if upgrade_url %}
+    <li>
+        <form method="post" action="{% url 'admin:'|add:upgrade_url %}">
+            {% csrf_token %}
+            <input type="hidden" name="post" value="yes">
+            <input type="hidden" name="action" value="upgrade_selected">
+            <input type="hidden" name="_selected_action" value="{{original.id}}">
+            <input type="submit" value="{% trans 'Launch mass upgrade operation' %}" class="object-tools-button">
+        </form>
+    </li>
+{% endif %}
+{{ block.super }}
+{% endblock %}

--- a/openwisp_firmware_upgrader/tests/test_admin.py
+++ b/openwisp_firmware_upgrader/tests/test_admin.py
@@ -65,6 +65,14 @@ class TestAdmin(BaseTestAdmin, TestCase):
         r = self.client.get(self.build_list_url)
         self.assertContains(r, '<option value="upgrade_selected">')
 
+    def test_upgrade_build_admin(self):
+        self._login()
+        b = self._create_build()
+        path = reverse(f'admin:{self.app_label}_build_change', args=[b.pk])
+        r = self.client.get(path)
+        self.assertEqual(r.status_code, 200)
+        self.assertContains(r, 'Launch mass upgrade operation')
+
     def test_upgrade_selected_error(self):
         self._login()
         b1 = self._create_build()


### PR DESCRIPTION
Closed issue by updating the chang_view of BuildAdmin
and adding a new change_form_overriden.html template.

Fixes #25