### PR TITLE
[fix] Made celery tasks resilient to failure #98

### DIFF
--- a/openwisp_firmware_upgrader/tasks.py
+++ b/openwisp_firmware_upgrader/tasks.py
@@ -31,7 +31,7 @@ def upgrade_firmware(self, operation_id):
         operation.upgrade(recoverable=recoverable)
     except SoftTimeLimitExceeded:
         operation.status = 'failed'
-        operation.log_line('Operation timed out.')
+        operation.log_line(_'Operation timed out.')
         logger.warn('SoftTimeLimitExceeded raised in upgrade_firmware task')
     except ObjectDoesNotExist:
         logger.warn(

--- a/openwisp_firmware_upgrader/tasks.py
+++ b/openwisp_firmware_upgrader/tasks.py
@@ -31,7 +31,7 @@ def upgrade_firmware(self, operation_id):
         operation.upgrade(recoverable=recoverable)
     except SoftTimeLimitExceeded:
         operation.status = 'failed'
-        operation.log_line(_'Operation timed out.')
+        operation.log_line(_('Operation timed out.'))
         logger.warn('SoftTimeLimitExceeded raised in upgrade_firmware task')
     except ObjectDoesNotExist:
         logger.warn(


### PR DESCRIPTION
- Added exception handling for "upgrade_firmware"
  and "batch_upgrade_operation" tasks
- Fixed minor typographical errors in test_tasks
- Made log warning translatable

Fixes #98