### PR TITLE
[refactor] Refactored URL schemes for ease of use

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,9 +135,8 @@ Other settings needed in ``settings.py``:
     urlpatterns = [
         url(r'^admin/', include(admin.site.urls)),
         url(r'', include('openwisp_controller.urls')),
-        url(r'^firmware/', include('openwisp_firmware_upgrader.private_storage.urls')),
+        url(r'', include('openwisp_firmware_upgrader.urls')),
         url(r'^api/v1/', include('openwisp_users.api.urls')),
-        url(r'^api/v1/', include('openwisp_firmware_upgrader.api.urls')),
         url(r'', include('openwisp_notifications.urls')),
     ]
 

--- a/openwisp_firmware_upgrader/api/urls.py
+++ b/openwisp_firmware_upgrader/api/urls.py
@@ -1,60 +1,53 @@
 from django.urls import include, path
 
-from openwisp_firmware_upgrader import settings as app_settings
-
 from . import views
 
 app_name = 'upgrader'
 
-urlpatterns = []
-
-if app_settings.FIRMWARE_UPGRADER_API:
-    urlpatterns += [
-        path(
-            'firmware/',
-            include(
-                [
-                    path('build/', views.build_list, name='api_build_list'),
-                    path(
-                        'build/<uuid:pk>/', views.build_detail, name='api_build_detail'
-                    ),
-                    path(
-                        'build/<uuid:pk>/upgrade/',
-                        views.api_batch_upgrade,
-                        name='api_build_batch_upgrade',
-                    ),
-                    path(
-                        'build/<uuid:build_pk>/image/',
-                        views.firmware_image_list,
-                        name='api_firmware_list',
-                    ),
-                    path(
-                        'build/<uuid:build_pk>/image/<uuid:pk>/',
-                        views.firmware_image_detail,
-                        name='api_firmware_detail',
-                    ),
-                    path(
-                        'build/<uuid:build_pk>/image/<pk>/download/',
-                        views.firmware_image_download,
-                        name='api_firmware_download',
-                    ),
-                    path('category/', views.category_list, name='api_category_list'),
-                    path(
-                        'category/<uuid:pk>/',
-                        views.category_detail,
-                        name='api_category_detail',
-                    ),
-                    path(
-                        'batch-upgrade-operation/',
-                        views.batch_upgrade_operation_list,
-                        name='api_batchupgradeoperation_list',
-                    ),
-                    path(
-                        'batch-upgrade-operation/<uuid:pk>/',
-                        views.batch_upgrade_operation_detail,
-                        name='api_batchupgradeoperation_detail',
-                    ),
-                ]
-            ),
+urlpatterns = [
+    path(
+        'firmware/',
+        include(
+            [
+                path('build/', views.build_list, name='api_build_list'),
+                path('build/<uuid:pk>/', views.build_detail, name='api_build_detail'),
+                path(
+                    'build/<uuid:pk>/upgrade/',
+                    views.api_batch_upgrade,
+                    name='api_build_batch_upgrade',
+                ),
+                path(
+                    'build/<uuid:build_pk>/image/',
+                    views.firmware_image_list,
+                    name='api_firmware_list',
+                ),
+                path(
+                    'build/<uuid:build_pk>/image/<uuid:pk>/',
+                    views.firmware_image_detail,
+                    name='api_firmware_detail',
+                ),
+                path(
+                    'build/<uuid:build_pk>/image/<pk>/download/',
+                    views.firmware_image_download,
+                    name='api_firmware_download',
+                ),
+                path('category/', views.category_list, name='api_category_list'),
+                path(
+                    'category/<uuid:pk>/',
+                    views.category_detail,
+                    name='api_category_detail',
+                ),
+                path(
+                    'batch-upgrade-operation/',
+                    views.batch_upgrade_operation_list,
+                    name='api_batchupgradeoperation_list',
+                ),
+                path(
+                    'batch-upgrade-operation/<uuid:pk>/',
+                    views.batch_upgrade_operation_detail,
+                    name='api_batchupgradeoperation_detail',
+                ),
+            ]
         ),
-    ]
+    ),
+]

--- a/openwisp_firmware_upgrader/urls.py
+++ b/openwisp_firmware_upgrader/urls.py
@@ -1,0 +1,12 @@
+from django.urls import include, path
+
+from openwisp_firmware_upgrader import settings as app_settings
+
+urlpatterns = [
+    path('firmware/', include('openwisp_firmware_upgrader.private_storage.urls')),
+]
+
+if app_settings.FIRMWARE_UPGRADER_API:
+    urlpatterns += [
+        path('api/v1/', include('openwisp_firmware_upgrader.api.urls')),
+    ]

--- a/tests/openwisp2/urls.py
+++ b/tests/openwisp2/urls.py
@@ -14,10 +14,8 @@ urlpatterns = [
     url(r'^admin/', admin.site.urls),
     url(r'', include('openwisp_controller.urls')),
     url(r'^$', redirect_view, name='index'),
-    url(r'^firmware/', include('openwisp_firmware_upgrader.private_storage.urls')),
-    url(r'^api/v1/', include('openwisp_utils.api.urls')),
+    url(r'', include('openwisp_firmware_upgrader.urls')),
     url(r'^api/v1/', include((get_api_urls(), 'users'), namespace='users')),
-    url(r'^api/v1/', include('openwisp_firmware_upgrader.api.urls')),
     url(r'', include('openwisp_notifications.urls')),
 ]
 


### PR DESCRIPTION
Before:
Users needed to add two entries in the root urls of the project.

After:
Users will need to add just one entry for this module.