### PR TITLE
[test] avoid error logging during tests #118

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -3,9 +3,11 @@
 
 import os
 import sys
+import logging
 
 sys.path.insert(0, 'tests')
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'openwisp2.settings')
+logging.disable(logging.CRITICAL)
 
 if __name__ == '__main__':
     from django.core.management import execute_from_command_line
@@ -17,3 +19,4 @@ if __name__ == '__main__':
     else:
         args.insert(2, 'openwisp2')
     execute_from_command_line(args)
+    logging.disable(logging.NOTSET)


### PR DESCRIPTION
Avoid error logging to print noisy output during tests,
disabled logging during test enabled after tests
Fixes #118