### PR TITLE
[fix] DeviceAdmin.conditional_inlines were not added to edit form

### DIFF
--- a/openwisp_firmware_upgrader/admin.py
+++ b/openwisp_firmware_upgrader/admin.py
@@ -325,9 +325,13 @@ class DeviceUpgradeOperationInline(UpgradeOperationInline):
         return qs
 
 
+# TODO:
+# DeviceAdmin.inlines += [DeviceFirmwareInline]
+# DeviceAdmin.conditional_inlines += [DeviceUpgradeOperationInline]
+old_device_admin_get_inlines = DeviceAdmin.get_inlines
 def device_admin_get_inlines(self, request, obj):
     # copy the list to avoid modifying the original data structure
-    inlines = self.inlines
+    inlines = old_device_admin_get_inlines(self, request, obj)
     if obj:
         inlines = list(inlines)  # copy
         inlines.append(DeviceFirmwareInline)

--- a/openwisp_firmware_upgrader/admin.py
+++ b/openwisp_firmware_upgrader/admin.py
@@ -329,6 +329,8 @@ class DeviceUpgradeOperationInline(UpgradeOperationInline):
 # DeviceAdmin.inlines += [DeviceFirmwareInline]
 # DeviceAdmin.conditional_inlines += [DeviceUpgradeOperationInline]
 old_device_admin_get_inlines = DeviceAdmin.get_inlines
+
+
 def device_admin_get_inlines(self, request, obj):
     # copy the list to avoid modifying the original data structure
     inlines = old_device_admin_get_inlines(self, request, obj)


### PR DESCRIPTION
openwisp-firmware-upgrader is overriding DeviceAdmin.get_inlines, so inlines added to DeviceAdmin.conditional_inlines are not shown.

This commit calls the old DeviceAdmin.get_inlines to get the inlines and the conditional inlines.

The problem was detected because SSH commands was not shown when using openwisp-firmware-upgrader