### PR TITLE
[models] Fixed 500 error on empty category #153

### DIFF
--- a/openwisp_firmware_upgrader/base/models.py
+++ b/openwisp_firmware_upgrader/base/models.py
@@ -113,9 +113,7 @@ class AbstractBuild(TimeStampedEditableModel):
             return
         if (
             load_model('Build')
-            .objects.filter(
-                category__organization=category.organization, os=self.os
-            )
+            .objects.filter(category__organization=category.organization, os=self.os)
             .exclude(pk=self.pk)
             .exists()
         ):

--- a/openwisp_firmware_upgrader/base/models.py
+++ b/openwisp_firmware_upgrader/base/models.py
@@ -105,7 +105,7 @@ class AbstractBuild(TimeStampedEditableModel):
 
     def clean(self):
         # Make sure that ('category__organization', 'os') is unique too
-        if not self.os:
+        if not (self.os and hasattr(self, "category")):
             return
         if (
             load_model('Build')

--- a/openwisp_firmware_upgrader/base/models.py
+++ b/openwisp_firmware_upgrader/base/models.py
@@ -105,12 +105,16 @@ class AbstractBuild(TimeStampedEditableModel):
 
     def clean(self):
         # Make sure that ('category__organization', 'os') is unique too
-        if not (self.os and hasattr(self, "category")):
+        try:
+            category = self.category
+        except ObjectDoesNotExist:
+            return
+        if not self.os:
             return
         if (
             load_model('Build')
             .objects.filter(
-                category__organization=self.category.organization, os=self.os
+                category__organization=category.organization, os=self.os
             )
             .exclude(pk=self.pk)
             .exists()
@@ -119,7 +123,7 @@ class AbstractBuild(TimeStampedEditableModel):
                 {
                     'os': _(
                         f'A build with this OS identifier ("{self.os}") and '
-                        f'organization ("{self.category.organization}") already exists'
+                        f'organization ("{category.organization}") already exists'
                     )
                 }
             )

--- a/openwisp_firmware_upgrader/tests/test_models.py
+++ b/openwisp_firmware_upgrader/tests/test_models.py
@@ -64,6 +64,18 @@ class TestModels(TestUpgraderMixin, TestCase):
         with self.subTest('validating the same object again should work'):
             b1.full_clean()
 
+        with self.subTest('validation error should be raised on empty category'):
+            try:
+                b2 = self._create_build(
+                    os=self.os + '_2', version='0.2', organization=org
+                )
+                b2.category = None
+                b2.full_clean()
+            except ValidationError as e:
+                self.assertIn('category', e.message_dict)
+            else:
+                self.fail('ValidationError not raised when build category is empty')
+
     def test_fw_str(self):
         fw = self._create_firmware_image()
         self.assertIn(str(fw.build), str(fw))


### PR DESCRIPTION
Closes #153 

Problem:
Trying to add a Firmware Build with an empty category but a non-empty OS identifier caused a 500 error.
The problem was in a uniqueness check that got executed before `category` field was validated. The code checked for unique (`category.organization`, `os`) for a build.
With an empty `os` field, this check was skipped (`if not self.os: return`) so the rest of the validation checks ran normally.

This change makes it so that the check is skipped when either `os` or `category` fields are empty. The empty field is caught in the rest of the validation checks and reported to the user. Test for the bug has been added.
