### PR TITLE
[ci] Add new python runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - 3.6
           - 3.7
           - 3.8
+          - 3.9
         django-version:
           - django~=3.0.0
           - django~=3.1.0


### PR DESCRIPTION
Add new python runtime, remove python 3.6 from CI
Fixes #160 