### PR TITLE
[test] Avoided noisy error logging during tests #118

### DIFF
--- a/openwisp_firmware_upgrader/tests/test_models.py
+++ b/openwisp_firmware_upgrader/tests/test_models.py
@@ -7,6 +7,8 @@ from celery.exceptions import Retry
 from django.core.exceptions import ValidationError
 from django.test import TestCase, TransactionTestCase
 
+from openwisp_utils.tests import capture_any_output
+
 from .. import settings as app_settings
 from ..hardware import FIRMWARE_IMAGE_MAP, REVERSE_FIRMWARE_IMAGE_MAP
 from ..swapper import load_model
@@ -251,6 +253,7 @@ class TestModels(TestUpgraderMixin, TestCase):
                 codename = '{}_{}'.format(action, model_name)
                 self.assertIn(codename, admin_permissions)
 
+    @capture_any_output()
     def test_create_for_device_validation_error(self):
         device_fw = self._create_device_firmware()
         device_fw.image.build.os = device_fw.device.os

--- a/openwisp_firmware_upgrader/tests/test_selenium.py
+++ b/openwisp_firmware_upgrader/tests/test_selenium.py
@@ -14,6 +14,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from openwisp_controller.tests.utils import SeleniumTestMixin
 from openwisp_firmware_upgrader.hardware import REVERSE_FIRMWARE_IMAGE_MAP
 from openwisp_firmware_upgrader.tests.base import TestUpgraderMixin
+from openwisp_utils.tests import capture_any_output
 
 from ..swapper import load_model
 
@@ -73,6 +74,7 @@ class TestDeviceAdmin(TestUpgraderMixin, SeleniumTestMixin, StaticLiveServerTest
             EC.visibility_of_element_located((By.XPATH, '//*[@id="site-name"]'))
         )
 
+    @capture_any_output()
     def test_restoring_deleted_device(self):
         org = self._get_org()
         category = self._get_category(organization=org)

--- a/openwisp_firmware_upgrader/tests/test_tasks.py
+++ b/openwisp_firmware_upgrader/tests/test_tasks.py
@@ -3,6 +3,8 @@ from unittest import mock
 from celery.exceptions import SoftTimeLimitExceeded
 from django.test import TransactionTestCase
 
+from openwisp_utils.tests import capture_any_output
+
 from .. import tasks
 from ..swapper import load_model
 from .base import TestUpgraderMixin
@@ -21,6 +23,7 @@ class TestTasks(TestUpgraderMixin, TransactionTestCase):
         'openwisp_firmware_upgrader.base.models.AbstractUpgradeOperation.upgrade',
         side_effect=SoftTimeLimitExceeded(),
     )
+    @capture_any_output()
     def test_upgrade_firmware_timeout(self, *args):
         device_fw = self._create_device_firmware(upgrade=True)
         self.assertEqual(UpgradeOperation.objects.count(), 1)
@@ -34,6 +37,7 @@ class TestTasks(TestUpgraderMixin, TransactionTestCase):
         'openwisp_firmware_upgrader.base.models.AbstractDeviceFirmware.create_upgrade_operation',
         side_effect=SoftTimeLimitExceeded(),
     )
+    @capture_any_output()
     def test_batch_upgrade_timeout(self, *args):
         env = self._create_upgrade_env()
         batch = BatchUpgradeOperation.objects.create(build=env['build2'])


### PR DESCRIPTION
Used openwisp-utils `@capture_any_output()` to avoid noisy
error logging output during tests, Closes #118

![Screenshot from 2022-02-04 01-55-36](https://user-images.githubusercontent.com/56113566/152423368-0f24b441-dac5-4d00-b466-214b5764ef48.png)

![Screenshot from 2022-02-04 01-55-25](https://user-images.githubusercontent.com/56113566/152423373-6ab579b3-af15-4578-af44-c816be755655.png)

