### PR TITLE
[fix] Added exception handling for SSHException

### DIFF
--- a/openwisp_firmware_upgrader/tests/test_openwrt_upgrader.py
+++ b/openwisp_firmware_upgrader/tests/test_openwrt_upgrader.py
@@ -279,7 +279,7 @@ class TestOpenwrtUpgrader(TestUpgraderMixin, TransactionTestCase):
     @patch.object(
         OpenWrtSshConnector,
         'connect',
-        side_effect=Exception('Connection failed'),
+        side_effect=SSHException('Connection failed'),
     )
     def test_connection_failure(self, connect, exec_command, putfo):
         (

--- a/openwisp_firmware_upgrader/upgraders/openwrt.py
+++ b/openwisp_firmware_upgrader/upgraders/openwrt.py
@@ -5,7 +5,7 @@ from time import sleep
 
 from billiard import Process, Queue
 from django.utils.translation import gettext_lazy as _
-from paramiko.ssh_exception import NoValidConnectionsError
+from paramiko.ssh_exception import NoValidConnectionsError, SSHException
 
 from openwisp_controller.connection.connectors.openwrt.ssh import OpenWrt as BaseOpenWrt
 
@@ -334,7 +334,7 @@ class OpenWrt(BaseOpenWrt):
             )
             try:
                 self.connect()
-            except (NoValidConnectionsError, socket.timeout) as error:
+            except (NoValidConnectionsError, socket.timeout, SSHException) as error:
                 self.log(
                     _(
                         'Device not reachable yet, ({0}).\n'


### PR DESCRIPTION
SSHException is raised by failures in SSH2 protocol negotiation
or logic errors by paramiko module.

Handling for the exception is required to make firmware upgrader
retry connection attempt.