### PR TITLE
[ci] Upgrade pyopenssl lib to fix build error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,11 @@ jobs:
           pip install ${{ matrix.django-version }}
 
       - name: Install openwisp-firmware-upgrader
-        run: pip install -e .
+        run: |
+          pip install -e .
+          # fixes build issue
+          # TODO: remove when openwisp-controller version is updated to 1.1.0
+          pip install -U pyOpenSSL
 
       - name: QA checks
         run: |


### PR DESCRIPTION
Fixes:
AttributeError: module 'lib' has no attribute 'SSL_CTX_set_ecdh_auto'.