### PR TITLE
Add Generic x86/64 firmware

### DIFF
--- a/openwisp_firmware_upgrader/hardware.py
+++ b/openwisp_firmware_upgrader/hardware.py
@@ -441,6 +441,13 @@ OPENWRT_FIRMWARE_IMAGE_MAP.update(
                 },
             ),
             (
+                'x86-64-generic-squashfs-combined.img.gz',
+                {
+                    'label': 'Generic x86/64 (various models)',
+                    'boards': ('QEMU/KVM',),
+                },
+            ),
+            (
                 'x86-geode-combined-squashfs.img.gz',
                 {
                     'label': 'x86 Geode(TM) Integrated Processor by AMD',


### PR DESCRIPTION
As I am testing OpenWISP I am running OpenWRT in a Linux QEMU/KVM (in Proxmox) and wanted to test the Firmware Upgrader -> As the VM is a x86_64 VM, I couldn't find the firmware image/map for that OpenWRT supported firmware (https://firmware-selector.openwrt.org/?target=x86%2F64&id=generic)