### PR TITLE
Add Dongwon T&I DW02-412H (128M) / KT GiGA WiFi home (128M)

### DIFF
--- a/openwisp_firmware_upgrader/hardware.py
+++ b/openwisp_firmware_upgrader/hardware.py
@@ -31,6 +31,13 @@ OPENWRT_FIRMWARE_IMAGE_MAP.update(
                 },
             ),
             (
+                'dongwon_dw02-412h-128m-squashfs-sysupgrade.bin',
+                {
+                    'label': 'Dongwon T&I DW02-412H (128M) / KT GiGA WiFi home (128M)',
+                    'boards': ('DW02-412H-128M-NAND',),
+                },
+            ),
+            (
                 'ipq40xx-generic-engenius_eap1300-squashfs-sysupgrade.bin',
                 {
                     'label': 'EnGenius EAP1300',


### PR DESCRIPTION
Adding support for Dongwon T&I DW02-412H (128M) / KT GiGA WiFi home (128M)