### PR TITLE
 [feature] REST API is missing endpoints for DeviceFirmware #206

### DIFF
--- a/openwisp_firmware_upgrader/api/serializers.py
+++ b/openwisp_firmware_upgrader/api/serializers.py
@@ -37,7 +37,6 @@ class CategoryRelationSerializer(BaseSerializer):
 class FirmwareImageSerializer(BaseSerializer):
     def validate(self, data):
         data['build'] = self.context['view'].get_parent_queryset().get()
-        return super().validate(data)
 
     class Meta(BaseMeta):
         model = FirmwareImage
@@ -88,15 +87,9 @@ class BatchUpgradeOperationSerializer(BatchUpgradeOperationListSerializer):
 
 
 class DeviceFirmwareSerializer(serializers.ModelSerializer):
-
-    image = FirmwareImageSerializer(read_only=True)
-
     class Meta:
         model = DeviceFirmware
         fields = ('image', 'installed')
-
-    def _validate(self, data):
-        return data
 
     def get_firmware_object(self, image_id):
         try:
@@ -107,16 +100,12 @@ class DeviceFirmwareSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         validated_data.update({'device_id': self.context.get('device_id')})
-        validated_data['image'] = self.get_firmware_object(self.context.get('image'))
-        queryset = DeviceFirmware.objects.filter(
-            device__pk=self.context.get('device_id')
-        )
-
         validated_data['installed'] = True
+        validated_data['image'] = self.get_firmware_object(self.data['image'])
         return super().create(validated_data)
 
     def update(self, instance, validated_data):
-        validated_data['image'] = self.get_firmware_object(self.context.get('image'))
         validated_data.update({'device_id': self.context.get('device_id')})
         validated_data['installed'] = True
+        validated_data['image'] = self.get_firmware_object(self.data['image'])
         return super().update(instance, validated_data)

--- a/openwisp_firmware_upgrader/api/serializers.py
+++ b/openwisp_firmware_upgrader/api/serializers.py
@@ -56,10 +56,12 @@ class UpgradeOperationSerializer(BaseSerializer):
         model = UpgradeOperation
         exclude = ['batch']
 
+
 class DeviceUpgradeOperationSerializer(BaseSerializer):
     class Meta:
         model = UpgradeOperation
         fields = ['id']
+
 
 class BatchUpgradeOperationListSerializer(BaseSerializer):
     build = BuildSerializer(read_only=True)

--- a/openwisp_firmware_upgrader/api/serializers.py
+++ b/openwisp_firmware_upgrader/api/serializers.py
@@ -37,6 +37,7 @@ class CategoryRelationSerializer(BaseSerializer):
 class FirmwareImageSerializer(BaseSerializer):
     def validate(self, data):
         data['build'] = self.context['view'].get_parent_queryset().get()
+        return super().validate(data)
 
     class Meta(BaseMeta):
         model = FirmwareImage

--- a/openwisp_firmware_upgrader/api/serializers.py
+++ b/openwisp_firmware_upgrader/api/serializers.py
@@ -56,6 +56,10 @@ class UpgradeOperationSerializer(BaseSerializer):
         model = UpgradeOperation
         exclude = ['batch']
 
+class DeviceUpgradeOperationSerializer(BaseSerializer):
+    class Meta:
+        model = UpgradeOperation
+        fields = ['id']
 
 class BatchUpgradeOperationListSerializer(BaseSerializer):
     build = BuildSerializer(read_only=True)

--- a/openwisp_firmware_upgrader/api/urls.py
+++ b/openwisp_firmware_upgrader/api/urls.py
@@ -62,6 +62,11 @@ urlpatterns = [
                     views.upgrade_operation_detail,
                     name='api_upgradeoperation_detail',
                 ),
+                path(
+                    'device/<uuid:pk>/firmware/',
+                    views.device_firmware,
+                    name='api_device_firmware',
+                ),
             ]
         ),
     ),

--- a/openwisp_firmware_upgrader/api/urls.py
+++ b/openwisp_firmware_upgrader/api/urls.py
@@ -51,17 +51,17 @@ urlpatterns = [
                     'device/<uuid:pk>/upgrade-operation/',
                     views.device_upgrade_operation_list,
                     name='api_deviceupgradeoperation_list',
-                ),        
+                ),
                 path(
                     'upgrade-operation/',
                     views.upgrade_operation_list,
                     name='api_upgradeoperation_list',
-                ),           
+                ),
                 path(
                     'upgrade-operation/<uuid:pk>/',
                     views.upgrade_operation_detail,
                     name='api_upgradeoperation_detail',
-                ),           
+                ),
             ]
         ),
     ),

--- a/openwisp_firmware_upgrader/api/urls.py
+++ b/openwisp_firmware_upgrader/api/urls.py
@@ -47,6 +47,21 @@ urlpatterns = [
                     views.batch_upgrade_operation_detail,
                     name='api_batchupgradeoperation_detail',
                 ),
+                path(
+                    'device/<uuid:pk>/upgrade-operation/',
+                    views.device_upgrade_operation_list,
+                    name='api_deviceupgradeoperation_list',
+                ),        
+                path(
+                    'upgrade-operation/',
+                    views.upgrade_operation_list,
+                    name='api_upgradeoperation_list',
+                ),           
+                path(
+                    'upgrade-operation/<uuid:pk>/',
+                    views.upgrade_operation_detail,
+                    name='api_upgradeoperation_detail',
+                ),           
             ]
         ),
     ),

--- a/openwisp_firmware_upgrader/api/views.py
+++ b/openwisp_firmware_upgrader/api/views.py
@@ -1,5 +1,4 @@
 from django.core.exceptions import ValidationError
-from django.shortcuts import get_object_or_404
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import filters, generics, pagination, serializers
 from rest_framework.exceptions import NotFound
@@ -135,16 +134,15 @@ class BatchUpgradeOperationDetailView(ProtectedAPIMixin, generics.RetrieveAPIVie
     lookup_fields = ['pk']
     organization_field = 'build__category__organization'
 
+
 class DeviceUpgradeOperationListView(ProtectedAPIMixin, generics.ListCreateAPIView):
-    queryset = (
-        UpgradeOperation.objects.all().order_by('-created')
-    )
+    queryset = UpgradeOperation.objects.all().order_by('-created')
     serializer_class = DeviceUpgradeOperationSerializer
     lookup_url_kwarg = 'pk'
     lookup_field = 'device_id'
     organization_field = 'organization'
 
-  
+
 class UpgradeOperationListView(ProtectedAPIMixin, generics.ListCreateAPIView):
     queryset = UpgradeOperation.objects.all()
     serializer_class = UpgradeOperationSerializer
@@ -153,13 +151,13 @@ class UpgradeOperationListView(ProtectedAPIMixin, generics.ListCreateAPIView):
     ordering_fields = ['device_id', 'created', 'modified']
     ordering = ['-device_id', '-created']
 
+
 class UpgradeOperationDetailView(ProtectedAPIMixin, generics.RetrieveAPIView):
-    queryset = (
-        UpgradeOperation.objects.all().order_by('-created')
-    )
+    queryset = UpgradeOperation.objects.all().order_by('-created')
     serializer_class = UpgradeOperationSerializer
     lookup_fields = ['pk']
     organization_field = 'organization'
+
 
 class FirmwareImageMixin(ProtectedAPIMixin):
     queryset = FirmwareImage.objects.all()
@@ -224,4 +222,3 @@ firmware_image_download = FirmwareImageDownloadView.as_view()
 device_upgrade_operation_list = DeviceUpgradeOperationListView.as_view()
 upgrade_operation_list = UpgradeOperationListView.as_view()
 upgrade_operation_detail = UpgradeOperationDetailView.as_view()
-

--- a/openwisp_firmware_upgrader/api/views.py
+++ b/openwisp_firmware_upgrader/api/views.py
@@ -156,9 +156,7 @@ class DeviceFirmwareView(ProtectedAPIMixin, generics.RetrieveUpdateAPIView):
 
     def get_serializer_context(self):
         context = super().get_serializer_context()
-        context.update(
-            {'device_id': self.kwargs['pk'], 'image': self.request.data['image']}
-        )
+        context.update({'device_id': self.kwargs['pk']})
         return context
 
     def update(self, request, *args, **kwargs):
@@ -177,7 +175,7 @@ class DeviceFirmwareView(ProtectedAPIMixin, generics.RetrieveUpdateAPIView):
             )
         self.perform_update(serializer)
         instance.save()
-        return Response(serializer.data)
+        return Response({'DeviceFirmware': serializer.data})
 
     def perform_create(self, serializer):
         serializer.save()

--- a/openwisp_firmware_upgrader/api/views.py
+++ b/openwisp_firmware_upgrader/api/views.py
@@ -1,8 +1,11 @@
 from django.core.exceptions import ValidationError
+from django.http import Http404
 from django_filters.rest_framework import DjangoFilterBackend
-from rest_framework import filters, generics, pagination, serializers
+from rest_framework import filters, generics, pagination, serializers, status
 from rest_framework.exceptions import NotFound
+from rest_framework.request import clone_request
 from rest_framework.response import Response
+from swapper import load_model as swapper_load_model
 
 from openwisp_firmware_upgrader import private_storage
 from openwisp_users.api.mixins import FilterByOrganizationManaged
@@ -12,11 +15,12 @@ from ..swapper import load_model
 from .serializers import (
     BatchUpgradeOperationListSerializer,
     BatchUpgradeOperationSerializer,
-    UpgradeOperationSerializer,
     BuildSerializer,
     CategorySerializer,
-    FirmwareImageSerializer,
+    DeviceFirmwareSerializer,
     DeviceUpgradeOperationSerializer,
+    FirmwareImageSerializer,
+    UpgradeOperationSerializer,
 )
 
 BatchUpgradeOperation = load_model('BatchUpgradeOperation')
@@ -24,6 +28,8 @@ UpgradeOperation = load_model('UpgradeOperation')
 Build = load_model('Build')
 Category = load_model('Category')
 FirmwareImage = load_model('FirmwareImage')
+DeviceFirmware = load_model('DeviceFirmware')
+Device = swapper_load_model('config', 'Device')
 
 
 class ListViewPagination(pagination.PageNumberPagination):
@@ -135,6 +141,66 @@ class BatchUpgradeOperationDetailView(ProtectedAPIMixin, generics.RetrieveAPIVie
     organization_field = 'build__category__organization'
 
 
+class DeviceFirmwareView(ProtectedAPIMixin, generics.RetrieveUpdateAPIView):
+    queryset = DeviceFirmware.objects.all()
+    serializer_class = DeviceFirmwareSerializer
+    lookup_field = 'device'
+    lookup_url_kwarg = 'pk'
+
+    def get_queryset(self):
+        qs = super().get_queryset()
+        try:
+            return qs.filter(device_id=self.kwargs['pk'])
+        except ValidationError:
+            return qs.none()
+
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        context.update(
+            {'device_id': self.kwargs['pk'], 'image': self.request.data['image']}
+        )
+        return context
+
+    def update(self, request, *args, **kwargs):
+        partial = kwargs.pop('partial', False)
+        instance = self.get_object_or_none()
+        serializer = self.get_serializer(instance, data=request.data, partial=partial)
+        serializer.is_valid(raise_exception=True)
+
+        if instance is None:
+            self.perform_create(serializer)
+            instance = self.get_object_or_none()
+            uo = instance.save()
+            return Response(
+                {'DeviceFirmware': serializer.data, 'UpgradeOperation': uo.id},
+                status=status.HTTP_201_CREATED,
+            )
+        self.perform_update(serializer)
+        instance.save()
+        return Response(serializer.data)
+
+    def perform_create(self, serializer):
+        serializer.save()
+
+    def perform_update(self, serializer):
+        serializer.save()
+
+    def get_object_or_none(self):
+        try:
+            return self.get_object()
+        except Http404:
+            if self.request.method == 'PUT':
+                # For PUT-as-create operation, we need to ensure that we have
+                # relevant permissions, as if this was a POST request. This
+                # will either raise a PermissionDenied exception, or simply
+                # return None.
+                self.check_permissions(clone_request(self.request, 'POST'))
+            else:
+                # PATCH requests where the object does not exist should still
+                # return a 404 response.
+                raise
+
+
 class DeviceUpgradeOperationListView(ProtectedAPIMixin, generics.ListCreateAPIView):
     queryset = UpgradeOperation.objects.all().order_by('-created')
     serializer_class = DeviceUpgradeOperationSerializer
@@ -222,3 +288,4 @@ firmware_image_download = FirmwareImageDownloadView.as_view()
 device_upgrade_operation_list = DeviceUpgradeOperationListView.as_view()
 upgrade_operation_list = UpgradeOperationListView.as_view()
 upgrade_operation_detail = UpgradeOperationDetailView.as_view()
+device_firmware = DeviceFirmwareView.as_view()

--- a/openwisp_firmware_upgrader/base/models.py
+++ b/openwisp_firmware_upgrader/base/models.py
@@ -321,13 +321,17 @@ class AbstractDeviceFirmware(TimeStampedEditableModel):
     def save(self, batch=None, upgrade=True, upgrade_options=None, *args, **kwargs):
         # if firwmare image has changed launch upgrade
         # upgrade won't be launched the first time
+        uo = None
         if upgrade and (self.image_has_changed or not self.installed):
             self.installed = False
             super().save(*args, **kwargs)
-            self.create_upgrade_operation(batch, upgrade_options=upgrade_options or {})
+            uo = self.create_upgrade_operation(
+                batch, upgrade_options=upgrade_options or {}
+            )
         else:
             super().save(*args, **kwargs)
         self._update_old_image()
+        return uo
 
     def _update_old_image(self):
         if hasattr(self, 'image'):


### PR DESCRIPTION
 [feature] REST API is missing endpoints for DeviceFirmware #206

The code adds three endpoints:

1.  upgrade-operation/ - List all the upgrade operation in the system
2.  upgrade-operation/<id>/ - Display detail of a particular upgrade id
3.  device/<id>/upgrade-operation/ - return a list of upgrade-operation ids for a gven device id