### PR TITLE
[fix] Avoid logging error for Device without DeviceConnection #249 

### DIFF
--- a/openwisp_firmware_upgrader/admin.py
+++ b/openwisp_firmware_upgrader/admin.py
@@ -43,6 +43,7 @@ FirmwareImage = load_model('FirmwareImage')
 Category = load_model('Category')
 Build = load_model('Build')
 Device = swapper.load_model('config', 'Device')
+DeviceConnection = swapper.load_model('connection', 'DeviceConnection')
 
 
 class BaseAdmin(MultitenantAdminMixin, TimeReadonlyAdminMixin, admin.ModelAdmin):
@@ -367,6 +368,30 @@ class DeviceFirmwareForm(forms.ModelForm):
     def __init__(self, device, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields['image'].queryset = self._get_image_queryset(device)
+        self.validate_has_device_connection()
+
+    def validate_has_device_connection(self):
+        """
+        Validate that the device being upgraded has at least one
+        DeviceConnection object. If the device does not have any
+        DeviceConnections, an error message is shown in the admin
+        form to guide the user to create a DeviceConnection for the
+        device before attempting an upgrade.
+        """
+        opts = self._meta
+        # The form is initialized with the error_message kwarg if the device being
+        # upgraded does not have any DeviceConnection objects.We don't need
+        # to perform any queries to the database to verify this, we just check
+        # if the error_message kwarg was passed to the form. If it was, we add
+        # the error message to the form errors so it is shown in the admin UI.
+        if hasattr(opts, 'error_messages'):
+            self._errors = forms.utils.ErrorDict()
+            error_messages = opts.error_messages or {}
+            for field, errors in error_messages.items():
+                self._errors[field] = self.error_class(
+                    error_class="nonfield", renderer=self.renderer
+                )
+                self._errors[field].extend(errors)
 
     def full_clean(self):
         super().full_clean()
@@ -420,10 +445,24 @@ class DeviceFirmwareInline(MultitenantAdminMixin, admin.StackedInline):
         return bool(obj)
 
     def get_formset(self, request, obj=None, **kwargs):
-        formset = super().get_formset(request, obj=obj, **kwargs)
+        schema = None
         if obj:
-            schema = get_upgrader_schema_for_device(obj)
-            formset.extra_context = json.dumps(schema, cls=DjangoJSONEncoder)
+            try:
+                schema = get_upgrader_schema_for_device(obj)
+            except DeviceConnection.DoesNotExist:
+                kwargs['error_messages'] = {
+                    '__all__': [
+                        _(
+                            'This device does not have a "Credential", therefore'
+                            ' it cannot be upgraded yet. Please add a credential'
+                            ' to this device from the "Credentials" section before'
+                            ' upgrading the device.'
+                        )
+                    ]
+                }
+        formset = super().get_formset(request, obj=obj, **kwargs)
+        if schema:
+            formset.extra_context = schema
         return formset
 
 

--- a/openwisp_firmware_upgrader/base/models.py
+++ b/openwisp_firmware_upgrader/base/models.py
@@ -308,7 +308,7 @@ class AbstractDeviceFirmware(TimeStampedEditableModel):
                 _(
                     'This device does not have a related connection object defined '
                     'yet and therefore it would not be possible to upgrade it, '
-                    'please add one in the section named "DEVICE CONNECTIONS"'
+                    'please add one in the section named "Credentials"'
                 )
             )
         if self.device.model not in self.image.boards:

--- a/openwisp_firmware_upgrader/templates/admin/firmware_upgrader/device_firmware_inline.html
+++ b/openwisp_firmware_upgrader/templates/admin/firmware_upgrader/device_firmware_inline.html
@@ -1,5 +1,5 @@
 {% include "admin/edit_inline/stacked.html" %}
 
 <script>
-var firmwareUpgraderSchema = {{ inline_admin_formset.formset.extra_context | default:"{}" | safe }}
+var firmwareUpgraderSchema = {{ inline_admin_formset.formset.extra_context | default:"null" | safe }}
 </script>

--- a/openwisp_firmware_upgrader/templates/admin/firmware_upgrader/device_firmware_inline.html
+++ b/openwisp_firmware_upgrader/templates/admin/firmware_upgrader/device_firmware_inline.html
@@ -1,5 +1,5 @@
 {% include "admin/edit_inline/stacked.html" %}
 
 <script>
-var firmwareUpgraderSchema = {{ inline_admin_formset.formset.extra_context | safe }}
+var firmwareUpgraderSchema = {{ inline_admin_formset.formset.extra_context | default:"{}" | safe }}
 </script>

--- a/openwisp_firmware_upgrader/tests/test_admin.py
+++ b/openwisp_firmware_upgrader/tests/test_admin.py
@@ -321,8 +321,11 @@ class TestAdmin(BaseTestAdmin, TestCase):
         self.assertEqual(response.status_code, 200)
 
     @capture_stderr()
+    @mock.patch(
+        'openwisp_firmware_upgrader.utils.get_upgrader_class_from_device_connection'
+    )
     def test_device_firmware_upgrade_without_device_connection(
-        self, captured_stderr, *args
+        self, captured_stderr, mocked_func, *args
     ):
         self._login()
         device_fw = self._create_device_firmware()
@@ -335,6 +338,7 @@ class TestAdmin(BaseTestAdmin, TestCase):
             '\'NoneType\' object has no attribute \'update_strategy\'',
             captured_stderr.getvalue(),
         )
+        mocked_func.assert_not_called()
         self.assertEqual(response.status_code, 200)
 
 

--- a/openwisp_firmware_upgrader/utils.py
+++ b/openwisp_firmware_upgrader/utils.py
@@ -28,6 +28,8 @@ def get_upgrader_class_for_device(device):
         update_strategy__icontains='ssh',
         enabled=True,
     ).first()
+    if not device_conn:
+        raise device.deviceconnection_set.model.DoesNotExist
     return get_upgrader_class_from_device_connection(device_conn)
 
 


### PR DESCRIPTION

Don't log error on device change page if the device does not
have any DeviceConnection objects.

Closes #249