### PR TITLE
[tests] Fixed "test_restoring_deleted_device" test

### DIFF
--- a/openwisp_firmware_upgrader/tests/test_selenium.py
+++ b/openwisp_firmware_upgrader/tests/test_selenium.py
@@ -95,7 +95,7 @@ class TestDeviceAdmin(TestUpgraderMixin, SeleniumTestMixin, StaticLiveServerTest
             reverse(f'admin:{self.config_app_label}_device_delete', args=[device.id])
         )
         self.web_driver.find_element(
-            by=By.XPATH, value='//*[@id="content"]/form/div/input[2]'
+            by=By.CSS_SELECTOR, value='#content form input[type="submit"]'
         ).click()
         self.assertEqual(Device.objects.count(), 0)
         self.assertEqual(DeviceConnection.objects.count(), 0)


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [ ] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Description of Changes

The test was failing because of changes in openwisp-controller.
 https://github.com/openwisp/openwisp-controller/pull/962
