### PR TITLE
[fix] Firmware image files are not deleted when deleting build

### DIFF
--- a/openwisp_firmware_upgrader/apps.py
+++ b/openwisp_firmware_upgrader/apps.py
@@ -42,19 +42,17 @@ class FirmwareUpdaterConfig(ApiAppConfig):
         Category = load_model('firmware_upgrader', 'Category')
 
         pre_delete.connect(
-            signals.delete_build_files,
-            sender=Build,
-            dispatch_uid='delete_build_files'
+            signals.delete_build_files, sender=Build, dispatch_uid='delete_build_files'
         )
         pre_delete.connect(
             signals.delete_category_files,
             sender=Category,
-            dispatch_uid='delete_category_files'
+            dispatch_uid='delete_category_files',
         )
         pre_delete.connect(
             signals.delete_organization_files,
             sender=Organization,
-            dispatch_uid='delete_org_files'
+            dispatch_uid='delete_org_files',
         )
 
     def register_menu_groups(self):

--- a/openwisp_firmware_upgrader/apps.py
+++ b/openwisp_firmware_upgrader/apps.py
@@ -26,6 +26,36 @@ class FirmwareUpdaterConfig(ApiAppConfig):
         super().ready(*args, **kwargs)
         self.register_menu_groups()
         self.connect_device_signals()
+        self.connect_firmware_signals()
+
+    def connect_firmware_signals(self):
+        """
+        Connects firmware related signals to their receivers
+        """
+        from django.db.models.signals import pre_delete
+        from swapper import load_model
+
+        from . import signals
+
+        Organization = load_model('openwisp_users', 'Organization')
+        Build = load_model('firmware_upgrader', 'Build')
+        Category = load_model('firmware_upgrader', 'Category')
+
+        pre_delete.connect(
+            signals.delete_build_files,
+            sender=Build,
+            dispatch_uid='delete_build_files'
+        )
+        pre_delete.connect(
+            signals.delete_category_files,
+            sender=Category,
+            dispatch_uid='delete_category_files'
+        )
+        pre_delete.connect(
+            signals.delete_organization_files,
+            sender=Organization,
+            dispatch_uid='delete_org_files'
+        )
 
     def register_menu_groups(self):
         register_menu_group(

--- a/openwisp_firmware_upgrader/base/models.py
+++ b/openwisp_firmware_upgrader/base/models.py
@@ -250,23 +250,11 @@ class AbstractFirmwareImage(TimeStampedEditableModel):
             raise ValidationError({'type': 'Could not find boards for this type'})
 
     def delete(self, *args, **kwargs):
+        """
+        Delete only deletes the database record
+        The actual file deletion is handled by the signal handlers
+        """
         super().delete(*args, **kwargs)
-        self._remove_file()
-
-    def _remove_file(self):
-        firmware_filename = self.file.name
-        self.file.storage.delete(firmware_filename)
-        # Delete the file directory
-        dir = os.path.split(firmware_filename)[0]
-        if dir:
-            try:
-                self.file.storage.delete(dir)
-            except OSError as error:
-                # A build can have multiple firmware images,
-                # therefore, deleting directory might not be
-                # always feasible.
-                if 'Directory not empty' not in str(error):
-                    raise error
 
     def _clean_type(self):
         """

--- a/openwisp_firmware_upgrader/signals.py
+++ b/openwisp_firmware_upgrader/signals.py
@@ -30,7 +30,11 @@ def delete_build_files(sender, instance, **kwargs):
     logger.info(f"Collected file paths: {paths}")
     if paths:
         logger.info("Scheduling delete_firmware_files task")
-        transaction.on_commit(lambda: delete_firmware_files.delay(paths))
+
+        def schedule_delete_task():
+            delete_firmware_files.delay(paths)
+
+        transaction.on_commit(schedule_delete_task)
 
 
 def delete_category_files(sender, instance, **kwargs):
@@ -49,7 +53,11 @@ def delete_category_files(sender, instance, **kwargs):
     logger.info(f"Collected file paths: {paths}")
     if paths:
         logger.info("Scheduling delete_firmware_files task")
-        transaction.on_commit(lambda: delete_firmware_files.delay(paths))
+
+        def schedule_delete_task():
+            delete_firmware_files.delay(paths)
+
+        transaction.on_commit(schedule_delete_task)
 
 
 def delete_organization_files(sender, instance, **kwargs):
@@ -71,4 +79,8 @@ def delete_organization_files(sender, instance, **kwargs):
     logger.info(f"Collected file paths: {paths}")
     if paths:
         logger.info("Scheduling delete_firmware_files task")
-        transaction.on_commit(lambda: delete_firmware_files.delay(paths))
+
+        def schedule_delete_task():
+            delete_firmware_files.delay(paths)
+
+        transaction.on_commit(schedule_delete_task)

--- a/openwisp_firmware_upgrader/signals.py
+++ b/openwisp_firmware_upgrader/signals.py
@@ -1,0 +1,74 @@
+import logging
+
+from django.db import transaction
+from swapper import load_model
+
+from .tasks import delete_firmware_files
+
+logger = logging.getLogger(__name__)
+
+
+def _collect_firmware_files(firmware_images):
+    """
+    Collects file paths from firmware images that need to be deleted
+    """
+    paths = []
+    for image in firmware_images:
+        if image.file:
+            paths.append(image.file.name)
+    return paths
+
+
+def delete_build_files(sender, instance, **kwargs):
+    """
+    Delete firmware files when a Build is deleted
+    """
+    logger.info(f"Build delete signal received for build {instance.pk}")
+    firmware_images = instance.firmwareimage_set.all()
+    logger.info(f"Found {firmware_images.count()} firmware images to delete")
+    paths = _collect_firmware_files(firmware_images)
+    logger.info(f"Collected file paths: {paths}")
+    if paths:
+        logger.info("Scheduling delete_firmware_files task")
+        transaction.on_commit(lambda: delete_firmware_files.delay(paths))
+
+
+def delete_category_files(sender, instance, **kwargs):
+    """
+    Delete firmware files when a Category is deleted
+    """
+    logger.info(f"Category delete signal received for category {instance.pk}")
+    firmware_images = []
+    builds = instance.build_set.all()
+    logger.info(f"Found {builds.count()} builds to process")
+    for build in builds:
+        images = build.firmwareimage_set.all()
+        logger.info(f"Found {images.count()} firmware images in build {build.pk}")
+        firmware_images.extend(images)
+    paths = _collect_firmware_files(firmware_images)
+    logger.info(f"Collected file paths: {paths}")
+    if paths:
+        logger.info("Scheduling delete_firmware_files task")
+        transaction.on_commit(lambda: delete_firmware_files.delay(paths))
+
+
+def delete_organization_files(sender, instance, **kwargs):
+    """
+    Delete firmware files when an Organization is deleted
+    """
+    logger.info(f"Organization delete signal received for organization {instance.pk}")
+    firmware_images = []
+    categories = instance.category_set.all()
+    logger.info(f"Found {categories.count()} categories to process")
+    for category in categories:
+        builds = category.build_set.all()
+        logger.info(f"Found {builds.count()} builds in category {category.pk}")
+        for build in builds:
+            images = build.firmwareimage_set.all()
+            logger.info(f"Found {images.count()} firmware images in build {build.pk}")
+            firmware_images.extend(images)
+    paths = _collect_firmware_files(firmware_images)
+    logger.info(f"Collected file paths: {paths}")
+    if paths:
+        logger.info("Scheduling delete_firmware_files task")
+        transaction.on_commit(lambda: delete_firmware_files.delay(paths))

--- a/openwisp_firmware_upgrader/signals.py
+++ b/openwisp_firmware_upgrader/signals.py
@@ -1,7 +1,6 @@
 import logging
 
 from django.db import transaction
-from swapper import load_model
 
 from .tasks import delete_firmware_files
 

--- a/openwisp_firmware_upgrader/tasks.py
+++ b/openwisp_firmware_upgrader/tasks.py
@@ -11,7 +11,6 @@ from openwisp_utils.tasks import OpenwispCeleryTask
 
 from . import settings as app_settings
 from .exceptions import RecoverableFailure
-from .private_storage.storage import file_system_private_storage
 from .swapper import load_model
 
 logger = logging.getLogger(__name__)

--- a/openwisp_firmware_upgrader/tasks.py
+++ b/openwisp_firmware_upgrader/tasks.py
@@ -10,8 +10,8 @@ from django.utils.translation import gettext_lazy as _
 from openwisp_utils.tasks import OpenwispCeleryTask
 
 from . import settings as app_settings
-from .private_storage.storage import file_system_private_storage
 from .exceptions import RecoverableFailure
+from .private_storage.storage import file_system_private_storage
 from .swapper import load_model
 
 logger = logging.getLogger(__name__)
@@ -29,7 +29,7 @@ def delete_firmware_files(self, file_paths):
         return
     logger.info(f"Using storage backend: {storage.__class__.__name__}")
     logger.info(f"Storage location: {storage.location}")
-    
+
     for path in file_paths:
         logger.info(f"Attempting to delete file: {path}")
         try:
@@ -52,11 +52,17 @@ def delete_firmware_files(self, file_paths):
                         if storage.exists(dir_path):
                             full_dir_path = storage.path(dir_path)
                             logger.info(f"Full directory path: {full_dir_path}")
-                            if not os.listdir(full_dir_path):  # Check if directory is empty
+                            if not os.listdir(
+                                full_dir_path
+                            ):  # Check if directory is empty
                                 storage.delete(dir_path)
-                                logger.info(f"Successfully deleted directory: {dir_path}")
+                                logger.info(
+                                    f"Successfully deleted directory: {dir_path}"
+                                )
                             else:
-                                logger.info(f"Directory not empty, skipping: {dir_path}")
+                                logger.info(
+                                    f"Directory not empty, skipping: {dir_path}"
+                                )
                     except OSError as error:
                         logger.warning(f'Error deleting directory {dir_path}: {error}')
             except Exception as e:

--- a/openwisp_firmware_upgrader/tasks.py
+++ b/openwisp_firmware_upgrader/tasks.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 import swapper
 from celery import shared_task
@@ -9,10 +10,59 @@ from django.utils.translation import gettext_lazy as _
 from openwisp_utils.tasks import OpenwispCeleryTask
 
 from . import settings as app_settings
+from .private_storage.storage import file_system_private_storage
 from .exceptions import RecoverableFailure
 from .swapper import load_model
 
 logger = logging.getLogger(__name__)
+
+
+@shared_task(base=OpenwispCeleryTask, bind=True)
+def delete_firmware_files(self, file_paths):
+    """
+    Deletes firmware files from storage in the background
+    """
+    logger.info(f"Starting delete_firmware_files task with paths: {file_paths}")
+    storage = app_settings.PRIVATE_STORAGE_INSTANCE
+    if not storage:
+        logger.error("No storage instance configured")
+        return
+    logger.info(f"Using storage backend: {storage.__class__.__name__}")
+    logger.info(f"Storage location: {storage.location}")
+    
+    for path in file_paths:
+        logger.info(f"Attempting to delete file: {path}")
+        try:
+            try:
+                exists = storage.exists(path)
+                logger.info(f"File exists: {exists}")
+                if exists:
+                    full_path = storage.path(path)
+                    logger.info(f"Full path: {full_path}")
+                    storage.delete(path)
+                    logger.info(f"Successfully deleted file: {path}")
+                else:
+                    logger.warning(f"File does not exist: {path}")
+
+                # Try to delete parent directory if empty
+                dir_path = '/'.join(path.split('/')[:-1])
+                if dir_path:
+                    logger.info(f"Attempting to delete directory: {dir_path}")
+                    try:
+                        if storage.exists(dir_path):
+                            full_dir_path = storage.path(dir_path)
+                            logger.info(f"Full directory path: {full_dir_path}")
+                            if not os.listdir(full_dir_path):  # Check if directory is empty
+                                storage.delete(dir_path)
+                                logger.info(f"Successfully deleted directory: {dir_path}")
+                            else:
+                                logger.info(f"Directory not empty, skipping: {dir_path}")
+                    except OSError as error:
+                        logger.warning(f'Error deleting directory {dir_path}: {error}')
+            except Exception as e:
+                logger.error(f'Error processing path {path}: {str(e)}')
+        except Exception as e:
+            logger.warning(f'Error deleting file {path}: {e}')
 
 
 @shared_task(

--- a/openwisp_firmware_upgrader/tests/test_signals.py
+++ b/openwisp_firmware_upgrader/tests/test_signals.py
@@ -14,6 +14,7 @@ Category = load_model('firmware_upgrader', 'Category')
 FirmwareImage = load_model('firmware_upgrader', 'FirmwareImage')
 Organization = load_model('openwisp_users', 'Organization')
 
+
 class TestSignals(TestUpgraderMixin, TestCase):
     def setUp(self):
         # Ensure PRIVATE_STORAGE_ROOT exists
@@ -47,8 +48,10 @@ class TestSignals(TestUpgraderMixin, TestCase):
         fw = self._create_firmware_image(build=build)
         file_path = fw.file.path
         self.assertTrue(os.path.exists(file_path))
-        
-        with patch('openwisp_firmware_upgrader.tasks.delete_firmware_files.delay') as mock:
+
+        with patch(
+            'openwisp_firmware_upgrader.tasks.delete_firmware_files.delay'
+        ) as mock:
             build.delete()
             mock.assert_called_once()
             file_paths = mock.call_args[0][0]
@@ -61,8 +64,10 @@ class TestSignals(TestUpgraderMixin, TestCase):
         build2 = self._create_build(category=category)
         fw1 = self._create_firmware_image(build=build1)
         fw2 = self._create_firmware_image(build=build2)
-        
-        with patch('openwisp_firmware_upgrader.tasks.delete_firmware_files.delay') as mock:
+
+        with patch(
+            'openwisp_firmware_upgrader.tasks.delete_firmware_files.delay'
+        ) as mock:
             category.delete()
             mock.assert_called_once()
             file_paths = mock.call_args[0][0]
@@ -78,8 +83,10 @@ class TestSignals(TestUpgraderMixin, TestCase):
         build2 = self._create_build(category=category2)
         fw1 = self._create_firmware_image(build=build1)
         fw2 = self._create_firmware_image(build=build2)
-        
-        with patch('openwisp_firmware_upgrader.tasks.delete_firmware_files.delay') as mock:
+
+        with patch(
+            'openwisp_firmware_upgrader.tasks.delete_firmware_files.delay'
+        ) as mock:
             org.delete()
             mock.assert_called_once()
             file_paths = mock.call_args[0][0]
@@ -120,16 +127,16 @@ class TestDeleteFirmwareFilesTask(TestUpgraderMixin, TransactionTestCase):
         fw = self._create_firmware_image(build=build)
         file_path = fw.file.path
         self.assertTrue(os.path.exists(file_path))
-        
+
         # Create a list of file paths to delete
         file_paths = [fw.file.name]
-        
+
         # Call the task directly
         delete_firmware_files(file_paths)
-        
+
         # Check if the file has been deleted
         self.assertFalse(os.path.exists(file_path))
-        
+
         # Check if the directory has been deleted
         dir_path = os.path.dirname(file_path)
         self.assertFalse(os.path.exists(dir_path))

--- a/openwisp_firmware_upgrader/tests/test_signals.py
+++ b/openwisp_firmware_upgrader/tests/test_signals.py
@@ -1,0 +1,135 @@
+import os
+from unittest.mock import patch
+
+from django.conf import settings
+from django.test import TestCase, TransactionTestCase
+from swapper import load_model
+
+from .. import settings as app_settings
+from ..tasks import delete_firmware_files
+from .base import TestUpgraderMixin
+
+Build = load_model('firmware_upgrader', 'Build')
+Category = load_model('firmware_upgrader', 'Category')
+FirmwareImage = load_model('firmware_upgrader', 'FirmwareImage')
+Organization = load_model('openwisp_users', 'Organization')
+
+class TestSignals(TestUpgraderMixin, TestCase):
+    def setUp(self):
+        # Ensure PRIVATE_STORAGE_ROOT exists
+        os.makedirs(settings.PRIVATE_STORAGE_ROOT, exist_ok=True)
+        self._create_test_files()
+
+    def tearDown(self):
+        self._remove_test_files()
+        super().tearDown()
+
+    def _create_test_files(self):
+        os.makedirs(settings.PRIVATE_STORAGE_ROOT, exist_ok=True)
+        with open(self.FAKE_IMAGE_PATH, 'wb') as f:
+            f.write(b'fake firmware image file')
+        with open(self.FAKE_IMAGE_PATH2, 'wb') as f:
+            f.write(b'fake firmware image file 2')
+
+    def _remove_test_files(self):
+        for path in [self.FAKE_IMAGE_PATH, self.FAKE_IMAGE_PATH2]:
+            try:
+                os.remove(path)
+            except FileNotFoundError:
+                pass
+        try:
+            os.rmdir(settings.PRIVATE_STORAGE_ROOT)
+        except (FileNotFoundError, OSError):
+            pass
+
+    def test_build_delete_files(self):
+        build = self._create_build()
+        fw = self._create_firmware_image(build=build)
+        file_path = fw.file.path
+        self.assertTrue(os.path.exists(file_path))
+        
+        with patch('openwisp_firmware_upgrader.tasks.delete_firmware_files.delay') as mock:
+            build.delete()
+            mock.assert_called_once()
+            file_paths = mock.call_args[0][0]
+            self.assertEqual(len(file_paths), 1)
+            self.assertEqual(file_paths[0], fw.file.name)
+
+    def test_category_delete_files(self):
+        category = self._create_category()
+        build1 = self._create_build(category=category)
+        build2 = self._create_build(category=category)
+        fw1 = self._create_firmware_image(build=build1)
+        fw2 = self._create_firmware_image(build=build2)
+        
+        with patch('openwisp_firmware_upgrader.tasks.delete_firmware_files.delay') as mock:
+            category.delete()
+            mock.assert_called_once()
+            file_paths = mock.call_args[0][0]
+            self.assertEqual(len(file_paths), 2)
+            self.assertIn(fw1.file.name, file_paths)
+            self.assertIn(fw2.file.name, file_paths)
+
+    def test_organization_delete_files(self):
+        org = self._get_org()
+        category1 = self._create_category(organization=org)
+        category2 = self._create_category(organization=org)
+        build1 = self._create_build(category=category1)
+        build2 = self._create_build(category=category2)
+        fw1 = self._create_firmware_image(build=build1)
+        fw2 = self._create_firmware_image(build=build2)
+        
+        with patch('openwisp_firmware_upgrader.tasks.delete_firmware_files.delay') as mock:
+            org.delete()
+            mock.assert_called_once()
+            file_paths = mock.call_args[0][0]
+            self.assertEqual(len(file_paths), 2)
+            self.assertIn(fw1.file.name, file_paths)
+            self.assertIn(fw2.file.name, file_paths)
+
+
+class TestDeleteFirmwareFilesTask(TestUpgraderMixin, TransactionTestCase):
+    def setUp(self):
+        # Ensure PRIVATE_STORAGE_ROOT exists
+        os.makedirs(settings.PRIVATE_STORAGE_ROOT, exist_ok=True)
+        self._create_test_files()
+
+    def tearDown(self):
+        self._remove_test_files()
+        super().tearDown()
+
+    def _create_test_files(self):
+        with open(self.FAKE_IMAGE_PATH, 'wb') as f:
+            f.write(b'fake firmware image file')
+        with open(self.FAKE_IMAGE_PATH2, 'wb') as f:
+            f.write(b'fake firmware image file 2')
+
+    def _remove_test_files(self):
+        for path in [self.FAKE_IMAGE_PATH, self.FAKE_IMAGE_PATH2]:
+            try:
+                os.remove(path)
+            except FileNotFoundError:
+                pass
+        try:
+            os.rmdir(settings.PRIVATE_STORAGE_ROOT)
+        except (FileNotFoundError, OSError):
+            pass
+
+    def test_delete_firmware_files(self):
+        build = self._create_build()
+        fw = self._create_firmware_image(build=build)
+        file_path = fw.file.path
+        self.assertTrue(os.path.exists(file_path))
+        
+        # Create a list of file paths to delete
+        file_paths = [fw.file.name]
+        
+        # Call the task directly
+        delete_firmware_files(file_paths)
+        
+        # Check if the file has been deleted
+        self.assertFalse(os.path.exists(file_path))
+        
+        # Check if the directory has been deleted
+        dir_path = os.path.dirname(file_path)
+        self.assertFalse(os.path.exists(dir_path))

--- a/openwisp_firmware_upgrader/tests/test_signals.py
+++ b/openwisp_firmware_upgrader/tests/test_signals.py
@@ -5,7 +5,6 @@ from django.conf import settings
 from django.test import TestCase, TransactionTestCase
 from swapper import load_model
 
-from .. import settings as app_settings
 from ..tasks import delete_firmware_files
 from .base import TestUpgraderMixin
 


### PR DESCRIPTION
Firmware image files are not deleted when deleting build

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #301 

