### PR TITLE
[chores] Fixed spacing of upgrade options

### DIFF
--- a/openwisp_firmware_upgrader/static/firmware-upgrader/css/device-firmware.css
+++ b/openwisp_firmware_upgrader/static/firmware-upgrader/css/device-firmware.css
@@ -7,10 +7,11 @@
   padding: 0px;
 }
 #id_devicefirmware-0-upgrade_options_jsoneditor input[type="checkbox"] {
-  vertical-align: middle;
+  position: relative;
+  bottom: -1px;
 }
 #main #id_devicefirmware-0-upgrade_options_jsoneditor .form-row {
-  padding: 0px;
+  padding: 5px 0;
   border-bottom: none;
 }
 #devicefirmware-group .form-row.field-upgrade_options {


### PR DESCRIPTION
At some point the upgrade options became too close to one another, felt crowded. This patch fixes this.

Before:

<img width="1070" height="211" alt="Screenshot from 2025-10-18 14-52-17" src="https://github.com/user-attachments/assets/6efe51f7-82f1-47e2-ad56-324bf48366f3" />

After:

<img width="1072" height="279" alt="Screenshot from 2025-10-18 14-51-18" src="https://github.com/user-attachments/assets/c50756b7-5735-4756-932a-783f75a73897" />
