### PR TITLE
[chores] Add Google Wifi (Gale), Engenius EWS2910P, and Extreme Networks WS-AP3825i to hardware.py

### DIFF
--- a/openwisp_firmware_upgrader/hardware.py
+++ b/openwisp_firmware_upgrader/hardware.py
@@ -53,7 +53,7 @@ OPENWRT_FIRMWARE_IMAGE_MAP.update(
                 },
             ),
             (
-                "realtek-rtl838x-engenius_ews2910p-squashfs-sysupgrade.bin"
+                "realtek-rtl838x-engenius_ews2910p-squashfs-sysupgrade.bin",
                 {
                     "label": "EnGenius EWS2910P",
                     "boards": ("EnGenius EWS2910P",),


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Description of Changes

Add Google Wifi (Gale), Engenius EWS2910P and Extreme Networks WS-AP3825i as supported devices for firmware upgrader.
