### PR TITLE
[feat] Allow REST API to specify upgrade_options for upgrade operations

### DIFF
--- a/openwisp_firmware_upgrader/api/serializers.py
+++ b/openwisp_firmware_upgrader/api/serializers.py
@@ -84,13 +84,13 @@ class BuildSerializer(BaseSerializer):
 class UpgradeOperationSerializer(serializers.ModelSerializer):
     class Meta:
         model = UpgradeOperation
-        fields = ("id", "device", "image", "status", "log", "modified", "created")
+        fields = ("id", "device", "image", "status", "log", "modified", "created", "upgrade_options")
 
 
 class DeviceUpgradeOperationSerializer(serializers.ModelSerializer):
     class Meta:
         model = UpgradeOperation
-        fields = ("id", "device", "image", "status", "log", "modified")
+        fields = ("id", "device", "image", "status", "log", "modified", "upgrade_options")
 
 
 class BatchUpgradeOperationListSerializer(BaseSerializer):
@@ -116,9 +116,11 @@ class BatchUpgradeOperationSerializer(BatchUpgradeOperationListSerializer):
 
 
 class DeviceFirmwareSerializer(ValidatedModelSerializer):
+    upgrade_options = serializers.JSONField(required=False, allow_null=True)
+
     class Meta:
         model = DeviceFirmware
-        fields = ("id", "image", "installed", "modified")
+        fields = ("id", "image", "installed", "modified", "upgrade_options")
         read_only_fields = ("installed", "modified")
 
     def validate(self, data):
@@ -142,7 +144,57 @@ class DeviceFirmwareSerializer(ValidatedModelSerializer):
                     )
                 }
             )
+        # Validate upgrade_options if provided
+        upgrade_options = data.get("upgrade_options")
+        if upgrade_options is not None:
+            # Create a temporary UpgradeOperation to validate upgrade_options
+            # This will trigger the model's validation logic
+            temp_operation = UpgradeOperation(
+                device=device,
+                image=image,
+                upgrade_options=upgrade_options or {},
+            )
+            try:
+                temp_operation.validate_upgrade_options()
+            except ValidationError as e:
+                raise serializers.ValidationError({"upgrade_options": e.messages})
         return super().validate(data)
+
+    def to_representation(self, instance):
+        """
+        Include upgrade_options from the latest upgrade operation if available.
+        """
+        ret = super().to_representation(instance)
+        # Get upgrade_options from the latest upgrade operation for this device
+        try:
+            latest_operation = instance.device.upgradeoperation_set.latest("created")
+            ret["upgrade_options"] = latest_operation.upgrade_options
+        except UpgradeOperation.DoesNotExist:
+            ret["upgrade_options"] = {}
+        return ret
+
+    def create(self, validated_data):
+        """
+        Extract upgrade_options from validated_data and pass it to model.save()
+        """
+        upgrade_options = validated_data.pop("upgrade_options", None)
+        if upgrade_options is None:
+            upgrade_options = {}
+        instance = DeviceFirmware(**validated_data)
+        instance.save(upgrade_options=upgrade_options)
+        return instance
+
+    def update(self, instance, validated_data):
+        """
+        Extract upgrade_options from validated_data and pass it to model.save()
+        """
+        upgrade_options = validated_data.pop("upgrade_options", None)
+        if upgrade_options is None:
+            upgrade_options = {}
+        for attr, value in validated_data.items():
+            setattr(instance, attr, value)
+        instance.save(upgrade_options=upgrade_options)
+        return instance
 
     def _get_device_object(self, device_id):
         try:

--- a/openwisp_firmware_upgrader/api/serializers.py
+++ b/openwisp_firmware_upgrader/api/serializers.py
@@ -84,13 +84,30 @@ class BuildSerializer(BaseSerializer):
 class UpgradeOperationSerializer(serializers.ModelSerializer):
     class Meta:
         model = UpgradeOperation
-        fields = ("id", "device", "image", "status", "log", "modified", "created", "upgrade_options")
+        fields = (
+            "id",
+            "device",
+            "image",
+            "status",
+            "log",
+            "modified",
+            "created",
+            "upgrade_options",
+        )
 
 
 class DeviceUpgradeOperationSerializer(serializers.ModelSerializer):
     class Meta:
         model = UpgradeOperation
-        fields = ("id", "device", "image", "status", "log", "modified", "upgrade_options")
+        fields = (
+            "id",
+            "device",
+            "image",
+            "status",
+            "log",
+            "modified",
+            "upgrade_options",
+        )
 
 
 class BatchUpgradeOperationListSerializer(BaseSerializer):

--- a/openwisp_firmware_upgrader/api/views.py
+++ b/openwisp_firmware_upgrader/api/views.py
@@ -88,7 +88,10 @@ class BuildBatchUpgradeView(ProtectedAPIMixin, generics.GenericAPIView):
         """
         Upgrades all the devices related to the specified build ID.
         """
-        upgrade_all = request.data.get("upgrade_all") is not None or request.POST.get("upgrade_all") is not None
+        upgrade_all = (
+            request.data.get("upgrade_all") is not None
+            or request.POST.get("upgrade_all") is not None
+        )
         upgrade_options = request.data.get("upgrade_options")
         # If not in request.data, try request.POST (for form data)
         if upgrade_options is None:
@@ -103,14 +106,18 @@ class BuildBatchUpgradeView(ProtectedAPIMixin, generics.GenericAPIView):
             upgrade_options = {}
         instance = self.get_object()
         # Validate upgrade_options by creating a temporary BatchUpgradeOperation
-        temp_batch = BatchUpgradeOperation(build=instance, upgrade_options=upgrade_options)
+        temp_batch = BatchUpgradeOperation(
+            build=instance, upgrade_options=upgrade_options
+        )
         try:
             temp_batch.full_clean()
         except ValidationError as e:
             return Response(
                 {"upgrade_options": e.messages}, status=status.HTTP_400_BAD_REQUEST
             )
-        batch = instance.batch_upgrade(firmwareless=upgrade_all, upgrade_options=upgrade_options)
+        batch = instance.batch_upgrade(
+            firmwareless=upgrade_all, upgrade_options=upgrade_options
+        )
         return Response({"batch": str(batch.pk)}, status=201)
 
     def get(self, request, pk):

--- a/openwisp_firmware_upgrader/api/views.py
+++ b/openwisp_firmware_upgrader/api/views.py
@@ -1,3 +1,5 @@
+import json
+
 import swapper
 from django.core.exceptions import ValidationError
 from django.http import Http404
@@ -86,9 +88,29 @@ class BuildBatchUpgradeView(ProtectedAPIMixin, generics.GenericAPIView):
         """
         Upgrades all the devices related to the specified build ID.
         """
-        upgrade_all = request.POST.get("upgrade_all") is not None
+        upgrade_all = request.data.get("upgrade_all") is not None or request.POST.get("upgrade_all") is not None
+        upgrade_options = request.data.get("upgrade_options")
+        # If not in request.data, try request.POST (for form data)
+        if upgrade_options is None:
+            upgrade_options = request.POST.get("upgrade_options")
+        # Parse upgrade_options if it's a string (from form data)
+        if isinstance(upgrade_options, str):
+            try:
+                upgrade_options = json.loads(upgrade_options)
+            except (json.JSONDecodeError, ValueError):
+                upgrade_options = {}
+        if upgrade_options is None:
+            upgrade_options = {}
         instance = self.get_object()
-        batch = instance.batch_upgrade(firmwareless=upgrade_all)
+        # Validate upgrade_options by creating a temporary BatchUpgradeOperation
+        temp_batch = BatchUpgradeOperation(build=instance, upgrade_options=upgrade_options)
+        try:
+            temp_batch.full_clean()
+        except ValidationError as e:
+            return Response(
+                {"upgrade_options": e.messages}, status=status.HTTP_400_BAD_REQUEST
+            )
+        batch = instance.batch_upgrade(firmwareless=upgrade_all, upgrade_options=upgrade_options)
         return Response({"batch": str(batch.pk)}, status=201)
 
     def get(self, request, pk):

--- a/openwisp_firmware_upgrader/base/models.py
+++ b/openwisp_firmware_upgrader/base/models.py
@@ -55,12 +55,15 @@ class UpgradeOptionsMixin(models.Model):
     def validate_upgrade_options(self):
         if not self.upgrade_options:
             return
-        if not getattr(self.upgrader_class, "SCHEMA"):
+        upgrader_class = self.upgrader_class
+        if not upgrader_class:
+            return
+        if not getattr(upgrader_class, "SCHEMA", None):
             raise ValidationError(
                 _("Using upgrade options is not allowed with this upgrader.")
             )
         try:
-            self.upgrader_class.validate_upgrade_options(self.upgrade_options)
+            upgrader_class.validate_upgrade_options(self.upgrade_options)
         except jsonschema.ValidationError:
             raise ValidationError("The upgrade options are invalid")
         except FirmwareUpgradeOptionsException as error:

--- a/openwisp_firmware_upgrader/tests/test_api.py
+++ b/openwisp_firmware_upgrader/tests/test_api.py
@@ -1,6 +1,4 @@
-import json
 import uuid
-from unittest import mock
 
 import swapper
 from django.contrib.auth import get_user_model
@@ -1882,7 +1880,7 @@ class TestUpgradeOperationViews(TestAPIUpgraderMixin, TestCase):
 
     def test_upgrade_operation_includes_upgrade_options(self):
         """Test that upgrade operation includes upgrade_options in response"""
-        device_fw = self._create_device_firmware(upgrade=True)
+        self._create_device_firmware(upgrade=True)
         upgrade_operation = UpgradeOperation.objects.first()
         upgrade_operation.upgrade_options = {"c": True, "F": True}
         upgrade_operation.save()

--- a/openwisp_firmware_upgrader/tests/test_api.py
+++ b/openwisp_firmware_upgrader/tests/test_api.py
@@ -1886,7 +1886,9 @@ class TestUpgradeOperationViews(TestAPIUpgraderMixin, TestCase):
         upgrade_operation = UpgradeOperation.objects.first()
         upgrade_operation.upgrade_options = {"c": True, "F": True}
         upgrade_operation.save()
-        url = reverse("upgrader:api_upgradeoperation_detail", args=[upgrade_operation.pk])
+        url = reverse(
+            "upgrader:api_upgradeoperation_detail", args=[upgrade_operation.pk]
+        )
         r = self.client.get(url)
         self.assertEqual(r.status_code, 200)
         self.assertIn("upgrade_options", r.data)

--- a/openwisp_firmware_upgrader/tests/test_api.py
+++ b/openwisp_firmware_upgrader/tests/test_api.py
@@ -321,7 +321,7 @@ class TestBuildViews(TestAPIUpgraderMixin, TestCase):
         self.assertEqual(DeviceFirmware.objects.count(), 0)
         with self.subTest("Existing build"):
             url = reverse("upgrader:api_build_batch_upgrade", args=[build.pk])
-            with self.assertNumQueries(8):
+            with self.assertNumQueries(10):
                 r = self.client.post(url)
             self.assertEqual(BatchUpgradeOperation.objects.count(), 1)
             self.assertEqual(DeviceFirmware.objects.count(), 0)
@@ -403,7 +403,7 @@ class TestBuildViews(TestAPIUpgraderMixin, TestCase):
             )
 
         with self.subTest("Test superuser can mass upgrade shared build"):
-            with self.assertNumQueries(5):
+            with self.assertNumQueries(7):
                 response = self.client.post(path)
             self.assertEqual(response.status_code, 201)
             batch = BatchUpgradeOperation.objects.first()
@@ -1159,7 +1159,7 @@ class TestDeviceFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
             url = reverse(
                 "upgrader:api_devicefirmware_detail", args=[device_fw1.device.pk]
             )
-            with self.assertNumQueries(9):
+            with self.assertNumQueries(13):
                 r = self.client.get(url, {"format": "api"})
             self.assertEqual(r.status_code, 200)
             serializer_detail = self._serialize_device_firmware(device_fw1)
@@ -1207,7 +1207,7 @@ class TestDeviceFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
         self.assertEqual(DeviceFirmware.objects.count(), 0)
         self.assertEqual(UpgradeOperation.objects.count(), 0)
 
-        with self.assertNumQueries(26):
+        with self.assertNumQueries(29):
             data = {"image": image1a.pk}
             # This API view allows the creation
             # of new devicefirmware objects with
@@ -1245,7 +1245,7 @@ class TestDeviceFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
         self.assertEqual(UpgradeOperation.objects.count(), 0)
 
         self.client.force_login(self.administrator)
-        with self.assertNumQueries(25):
+        with self.assertNumQueries(28):
             data = {"image": shared_image.pk}
             r = self.client.put(
                 f"{path}?format=api", data, content_type="application/json"
@@ -1275,7 +1275,7 @@ class TestDeviceFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
         self.assertEqual(DeviceFirmware.objects.count(), 2)
         self.assertEqual(UpgradeOperation.objects.count(), 0)
 
-        with self.assertNumQueries(27):
+        with self.assertNumQueries(30):
             data = {"image": image2a.pk}
             r = self.client.put(
                 f"{url}?format=api", data, content_type="application/json"
@@ -1314,7 +1314,7 @@ class TestDeviceFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
         self.assertEqual(DeviceFirmware.objects.count(), 2)
         self.assertEqual(UpgradeOperation.objects.count(), 0)
 
-        with self.assertNumQueries(27):
+        with self.assertNumQueries(31):
             data = {"image": image2a.pk}
             r = self.client.patch(
                 f"{url}?format=api", data, content_type="application/json"
@@ -1349,7 +1349,7 @@ class TestDeviceFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
         with self.subTest("Test device firmware detail org manager"):
             self._login("org1_manager", "tester")
             url = reverse("upgrader:api_devicefirmware_detail", args=[d1.pk])
-            with self.assertNumQueries(7):
+            with self.assertNumQueries(8):
                 r = self.client.get(url, {"format": "api"})
             self.assertEqual(r.status_code, 200)
             serializer_detail = self._serialize_device_firmware(device_fw1)
@@ -1382,7 +1382,7 @@ class TestDeviceFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
         with self.subTest("Test device firmware detail org admin"):
             self._login("org_admin", "tester")
             url = reverse("upgrader:api_devicefirmware_detail", args=[d1.pk])
-            with self.assertNumQueries(6):
+            with self.assertNumQueries(10):
                 r = self.client.get(url, {"format": "api"})
             self.assertEqual(r.status_code, 200)
             serializer_detail = self._serialize_device_firmware(device_fw1)
@@ -1390,7 +1390,7 @@ class TestDeviceFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
             self.assertContains(r, f"{image1}</option>")
             self.assertNotContains(r, f"{image2}</option>")
             url = reverse("upgrader:api_devicefirmware_detail", args=[d2.pk])
-            with self.assertNumQueries(6):
+            with self.assertNumQueries(10):
                 r = self.client.get(url, {"format": "api"})
             self.assertEqual(r.status_code, 200)
             serializer_detail = self._serialize_device_firmware(device_fw2)

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -14,8 +14,8 @@ DATABASES = {
         "NAME": "openwisp-firmware-upgrader.db",
     }
 }
-
-SPATIALITE_LIBRARY_PATH = "mod_spatialite.so"
+SPATIALITE_LIBRARY_PATH="/opt/homebrew/Cellar/libspatialite/5.1.0_1/lib/mod_spatialite.dylib"
+# SPATIALITE_LIBRARY_PATH = "mod_spatialite.so"
 
 SECRET_KEY = "fn)t*+$)ugeyip6-#txyy$5wf2ervc0d2n#h)qb)y5@ly$t*@w"
 

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -14,10 +14,8 @@ DATABASES = {
         "NAME": "openwisp-firmware-upgrader.db",
     }
 }
-SPATIALITE_LIBRARY_PATH = (
-    "/opt/homebrew/Cellar/libspatialite/5.1.0_1/lib/mod_spatialite.dylib"
-)
-# SPATIALITE_LIBRARY_PATH = "mod_spatialite.so"
+
+SPATIALITE_LIBRARY_PATH = "mod_spatialite.so"
 
 SECRET_KEY = "fn)t*+$)ugeyip6-#txyy$5wf2ervc0d2n#h)qb)y5@ly$t*@w"
 

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -14,7 +14,9 @@ DATABASES = {
         "NAME": "openwisp-firmware-upgrader.db",
     }
 }
-SPATIALITE_LIBRARY_PATH="/opt/homebrew/Cellar/libspatialite/5.1.0_1/lib/mod_spatialite.dylib"
+SPATIALITE_LIBRARY_PATH = (
+    "/opt/homebrew/Cellar/libspatialite/5.1.0_1/lib/mod_spatialite.dylib"
+)
 # SPATIALITE_LIBRARY_PATH = "mod_spatialite.so"
 
 SECRET_KEY = "fn)t*+$)ugeyip6-#txyy$5wf2ervc0d2n#h)qb)y5@ly$t*@w"


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #366

Please [open a new issue](https://github.com/openwisp/openwisp-firmware-upgrader/issues/new/choose) if there isn't an existing issue yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for custom upgrade options during firmware upgrades at device and batch levels.
  * Upgrade operation details now display configured options for transparency.
  * Enhanced validation ensures upgrade options are properly configured across all upgrade scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->