### PR TITLE
[chores] Replaced hardcoded colors with openwisp-utils theme variable…

### DIFF
--- a/openwisp_firmware_upgrader/static/firmware-upgrader/css/batch-upgrade-operation.css
+++ b/openwisp_firmware_upgrader/static/firmware-upgrader/css/batch-upgrade-operation.css
@@ -142,24 +142,24 @@
 }
 
 .upgrade-status-container .upgrade-progress-fill.in-progress {
-  background-color: #70bf2b;
+  background-color: var(--ow-color-success);
 }
 
 .upgrade-status-container .upgrade-progress-fill.success,
 .upgrade-status-container .upgrade-progress-fill.completed-successfully {
-  background-color: #70bf2b;
+  background-color: var(--ow-color-success);
 }
 
 .upgrade-status-container .upgrade-progress-fill.failed {
-  background-color: #dc3545;
+  background-color: var(--ow-btn-danger-bg);
 }
 
 .upgrade-status-container .upgrade-progress-fill.aborted {
-  background-color: #6c757d;
+  background-color: var(--ow-color-fg-dark);
 }
 
 .upgrade-status-container .upgrade-progress-fill.cancelled {
-  background-color: #8b8b8b;
+  background-color: var(--ow-color-fg-dark);
 }
 
 .upgrade-status-container span {
@@ -173,28 +173,28 @@
 }
 
 .upgrade-status-in-progress {
-  color: #70bf2b;
+  color: var(--ow-color-success);
 }
 
 .upgrade-status-success,
 .upgrade-status-completed-successfully {
-  color: #70bf2b;
+  color: var(--ow-color-success);
 }
 
 .upgrade-status-failed {
-  color: #dc3545;
+  color: var(--ow-btn-danger-bg);
 }
 
 .upgrade-status-aborted {
-  color: #6c757d;
+  color: var(--ow-color-fg-dark);
 }
 
 .upgrade-status-cancelled {
-  color: #8b8b8b;
+  color: var(--ow-color-fg-dark);
 }
 
 .upgrade-status-idle {
-  color: #6c757d;
+  color: var(--ow-color-fg-dark);
 }
 
 .batch-main-progress {
@@ -207,7 +207,7 @@
 .batch-main-progress .upgrade-progress-bar {
   width: 300px;
   height: 12px;
-  background-color: #d9d9d9;
+  background-color: var(--ow-color-fg-medium);
   border-radius: 4px;
   overflow: hidden;
   border: 1px solid var(--border-color);
@@ -220,32 +220,32 @@
 }
 
 .batch-main-progress .upgrade-progress-fill.idle {
-  background-color: #6c757d;
+  background-color: var(--ow-color-fg-dark);
 }
 
 .batch-main-progress .upgrade-progress-fill.in-progress {
-  background-color: #70bf2b;
+  background-color: var(--ow-color-success);
 }
 
 .batch-main-progress .upgrade-progress-fill.success,
 .batch-main-progress .upgrade-progress-fill.completed-successfully {
-  background-color: #70bf2b;
+  background-color: var(--ow-color-success);
 }
 
 .batch-main-progress .upgrade-progress-fill.failed {
-  background-color: #dc3545;
+  background-color: var(--ow-btn-danger-bg);
 }
 
 .batch-main-progress .upgrade-progress-fill.aborted {
-  background-color: #6c757d;
+  background-color: var(--ow-color-fg-dark);
 }
 
 .batch-main-progress .upgrade-progress-fill.cancelled {
-  background-color: #8b8b8b;
+  background-color: var(--ow-color-fg-dark);
 }
 
 .batch-main-progress .upgrade-progress-fill.partial-success {
-  background-color: #ff9800;
+  background-color: var(--ow-color-primary);
 }
 
 .batch-main-progress .upgrade-progress-text {

--- a/openwisp_firmware_upgrader/static/firmware-upgrader/css/batch-upgrade-operation.css
+++ b/openwisp_firmware_upgrader/static/firmware-upgrader/css/batch-upgrade-operation.css
@@ -151,11 +151,11 @@
 }
 
 .upgrade-status-container .upgrade-progress-fill.failed {
-  background-color: var(--ow-btn-danger-bg);
+  background-color: var(--ow-color-danger);
 }
 
 .upgrade-status-container .upgrade-progress-fill.aborted {
-  background-color: var(--ow-color-fg-dark);
+  background-color: var(--ow-color-fg-darker);
 }
 
 .upgrade-status-container .upgrade-progress-fill.cancelled {
@@ -182,11 +182,11 @@
 }
 
 .upgrade-status-failed {
-  color: var(--ow-btn-danger-bg);
+  color: var(--ow-color-danger);
 }
 
 .upgrade-status-aborted {
-  color: var(--ow-color-fg-dark);
+  color: var(--ow-color-fg-darker);
 }
 
 .upgrade-status-cancelled {
@@ -233,11 +233,11 @@
 }
 
 .batch-main-progress .upgrade-progress-fill.failed {
-  background-color: var(--ow-btn-danger-bg);
+  background-color: var(--ow-color-danger);
 }
 
 .batch-main-progress .upgrade-progress-fill.aborted {
-  background-color: var(--ow-color-fg-dark);
+  background-color: var(--ow-color-fg-darker);
 }
 
 .batch-main-progress .upgrade-progress-fill.cancelled {
@@ -245,7 +245,7 @@
 }
 
 .batch-main-progress .upgrade-progress-fill.partial-success {
-  background-color: var(--ow-color-primary);
+  background-color: var(--ow-color-warning);
 }
 
 .batch-main-progress .upgrade-progress-text {

--- a/openwisp_firmware_upgrader/static/firmware-upgrader/css/upgrade-progress.css
+++ b/openwisp_firmware_upgrader/static/firmware-upgrader/css/upgrade-progress.css
@@ -13,7 +13,7 @@
 .upgrade-progress-bar {
   width: 300px;
   height: 12px;
-  background-color: #d9d9d9;
+  background-color: var(--ow-color-fg-medium);
   border-radius: 4px;
   overflow: hidden;
   display: inline-block;
@@ -23,30 +23,30 @@
 
 .upgrade-progress-fill {
   height: 100%;
-  background-color: #70bf2b;
+  background-color: var(--ow-color-success);
   transition: width 0.5s ease;
   border-radius: 2px;
   position: relative;
 }
 
 .upgrade-progress-fill.success {
-  background-color: #70bf2b;
+  background-color: var(--ow-color-success);
 }
 
 .upgrade-progress-fill.failed {
-  background-color: #dc3545;
+  background-color: var(--ow-btn-danger-bg);
 }
 
 .upgrade-progress-fill.aborted {
-  background-color: #464646;
+  background-color: var(--ow-color-fg-dark);
 }
 
 .upgrade-progress-fill.cancelled {
-  background-color: #8b8b8b;
+  background-color: var(--ow-color-fg-dark);
 }
 
 .upgrade-progress-fill.in-progress {
-  background-color: #70bf2b;
+  background-color: var(--ow-color-success);
 }
 
 .upgrade-progress-text {

--- a/openwisp_firmware_upgrader/static/firmware-upgrader/css/upgrade-progress.css
+++ b/openwisp_firmware_upgrader/static/firmware-upgrader/css/upgrade-progress.css
@@ -34,11 +34,11 @@
 }
 
 .upgrade-progress-fill.failed {
-  background-color: var(--ow-btn-danger-bg);
+  background-color: var(--ow-color-danger);
 }
 
 .upgrade-progress-fill.aborted {
-  background-color: var(--ow-color-fg-dark);
+  background-color: var(--ow-color-fg-darker);
 }
 
 .upgrade-progress-fill.cancelled {


### PR DESCRIPTION
Replaced hardcoded color values in CSS files with the theme color variables defined in openwisp-utils

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [ ] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #360 .

## Description of Changes
Replaced hardcoded color values with CSS custom properties from openwisp-utils, ensuring colors stay consistent