### PR TITLE
docs(api): fix mass upgrade / batch upgrade terminology inconsistency #345

### DIFF
--- a/docs/user/rest-api.rst
+++ b/docs/user/rest-api.rst
@@ -202,7 +202,7 @@ Download Firmware Image
     GET /api/v1/firmware-upgrader/build/{build_id}/image/{id}/download/
 
 Perform Mass Upgrade
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 Upgrades all the devices related to the specified build ID.
 
@@ -230,7 +230,7 @@ Example with filters:
     }
 
 Dry-run Mass Upgrade
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 Returns a list representing the ``DeviceFirmware`` and ``Device``
 instances that would be upgraded if POST is used.

--- a/docs/user/rest-api.rst
+++ b/docs/user/rest-api.rst
@@ -306,6 +306,12 @@ Delete a Firmware Category
 List Upgrade Operations
 ~~~~~~~~~~~~~~~~~~~~~~~
 
+.. note::
+
+    This documentation uses "mass upgrade" as the descriptive term, but
+    the REST API still exposes identifiers such as
+    ``batch-upgrade-operation`` and ``batch`` for backward compatibility.
+
 .. code-block:: text
 
     GET /api/v1/firmware-upgrader/upgrade-operation/

--- a/docs/user/rest-api.rst
+++ b/docs/user/rest-api.rst
@@ -80,7 +80,7 @@ List Mass Upgrade Operations
 
 **Available filters**
 
-The list of batch upgrade operations provides the following filters:
+The list of mass upgrade operations provides the following filters:
 
 - ``build`` (Firmware build ID)
 - ``status`` (One of: idle, in-progress, success, failed, cancelled)
@@ -201,7 +201,7 @@ Download Firmware Image
 
     GET /api/v1/firmware-upgrader/build/{build_id}/image/{id}/download/
 
-Perform Batch Upgrade
+Perform Mass Upgrade
 ~~~~~~~~~~~~~~~~~~~~~
 
 Upgrades all the devices related to the specified build ID.
@@ -212,7 +212,7 @@ Upgrades all the devices related to the specified build ID.
 
 **Optional Parameters**
 
-The batch upgrade operation accepts the following optional parameters in
+The mass upgrade operation accepts the following optional parameters in
 the request body:
 
 - ``group`` (Device group ID): limit the upgrade to devices belonging to a
@@ -229,7 +229,7 @@ Example with filters:
         "location": "{location_id}"
     }
 
-Dry-run Batch Upgrade
+Dry-run Mass Upgrade
 ~~~~~~~~~~~~~~~~~~~~~
 
 Returns a list representing the ``DeviceFirmware`` and ``Device``
@@ -244,7 +244,7 @@ exists for a device which would be upgraded.
 
 **Optional Query Parameters**
 
-The dry-run batch upgrade operation accepts the following optional query
+The dry-run mass upgrade operation accepts the following optional query
 parameters:
 
 - ``group`` (Device group ID): limit the preview to devices belonging to a

--- a/docs/user/upgrade-status.rst
+++ b/docs/user/upgrade-status.rst
@@ -181,5 +181,6 @@ these updates.
 **Upgrade Logs**: Each status change is logged with detailed information
 about what occurred during the upgrade process.
 
-**Mass Upgrade Operations**: When performing mass upgrades, you can monitor the
-status of individual device upgrades within the mass upgrade operation.
+**Mass Upgrade Operations**: When performing mass upgrades, you can
+monitor the status of individual device upgrades within the mass upgrade
+operation.

--- a/docs/user/upgrade-status.rst
+++ b/docs/user/upgrade-status.rst
@@ -181,5 +181,5 @@ these updates.
 **Upgrade Logs**: Each status change is logged with detailed information
 about what occurred during the upgrade process.
 
-**Batch Operations**: When performing mass upgrades, you can monitor the
-status of individual device upgrades within the batch operation.
+**Mass Upgrade Operations**: When performing mass upgrades, you can monitor the
+status of individual device upgrades within the mass upgrade operation.

--- a/docs/user/websocket-api.rst
+++ b/docs/user/websocket-api.rst
@@ -113,7 +113,7 @@ A mass upgrade containing multiple operations.
 Client Message
 ++++++++++++++
 
-To request the current state of the mass:
+To request the current state of the batch:
 
 .. code-block:: javascript
 

--- a/docs/user/websocket-api.rst
+++ b/docs/user/websocket-api.rst
@@ -97,7 +97,7 @@ The message structure is identical to the response returned for
 ``request_current_state``.
 
 2. Mass Upgrade Operation
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Connection URL:
 

--- a/docs/user/websocket-api.rst
+++ b/docs/user/websocket-api.rst
@@ -96,7 +96,7 @@ After the connection is established, the server pushes
 The message structure is identical to the response returned for
 ``request_current_state``.
 
-2. Batch Upgrade Operation
+2. Mass Upgrade Operation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Connection URL:
@@ -108,12 +108,12 @@ Connection URL:
 Scope
 +++++
 
-A batch upgrade containing multiple operations.
+A mass upgrade containing multiple operations.
 
 Client Message
 ++++++++++++++
 
-To request the current state of the batch:
+To request the current state of the mass:
 
 .. code-block:: javascript
 

--- a/docs/user/websocket-api.rst
+++ b/docs/user/websocket-api.rst
@@ -99,9 +99,15 @@ The message structure is identical to the response returned for
 2. Mass Upgrade Operation
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. note::
+
+    This documentation uses "mass upgrade" as the descriptive term, but
+    the WebSocket URL path still uses ``batch-upgrade-operation`` for
+    backward compatibility.
+
 Connection URL:
 
-::
+.. code-block:: text
 
     wss://<host>/ws/firmware-upgrader/batch-upgrade-operation/<batch_id>/
 


### PR DESCRIPTION
## Checklist

- [x] I have read the OpenWISP Contributing Guidelines.
- [ ] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #345

## Description of Changes

This PR fixes inconsistent terminology in the REST API documentation.

Some sections referred to firmware upgrade operations as "batch upgrade"
while others used "mass upgrade". This change standardizes the wording
in descriptive text while keeping API endpoints and identifiers unchanged.
