### PR TITLE
[fix] Prevent 500 and warn about credentialless devices on mass upgrade #302

### DIFF
--- a/openwisp_firmware_upgrader/admin.py
+++ b/openwisp_firmware_upgrader/admin.py
@@ -40,6 +40,7 @@ from .utils import get_upgrader_schema_for_device
 from .widgets import FirmwareSchemaWidget, MassUpgradeSelect2Widget
 
 logger = logging.getLogger(__name__)
+MAX_CREDENTIALLESS_DISPLAY = 5
 BatchUpgradeOperation = load_model("BatchUpgradeOperation")
 UpgradeOperation = load_model("UpgradeOperation")
 DeviceFirmware = load_model("DeviceFirmware")
@@ -261,6 +262,45 @@ class BuildAdmin(BaseAdmin):
         )
         related_device_fw = result["device_firmwares"]
         firmwareless_devices = result["devices"]
+        # Identify devices that lack valid SSH credentials so admins are informed.
+        valid_device_ids = DeviceConnection.objects.filter(
+            update_strategy__icontains="ssh",
+            enabled=True,
+        ).values("device_id")
+        credentialless_fw = related_device_fw.exclude(device_id__in=valid_device_ids)
+        credentialless_firmwareless = firmwareless_devices.exclude(
+            pk__in=valid_device_ids
+        )
+        total_credentialless = (
+            credentialless_fw.count() + credentialless_firmwareless.count()
+        )
+        device_app_label = Device._meta.app_label
+        credentialless_devices = []
+        for df in credentialless_fw.select_related("device")[
+            :MAX_CREDENTIALLESS_DISPLAY
+        ]:
+            credentialless_devices.append(
+                {
+                    "name": df.device.name,
+                    "url": reverse(
+                        f"admin:{device_app_label}_device_change",
+                        args=[df.device_id],
+                    ),
+                }
+            )
+        remaining = MAX_CREDENTIALLESS_DISPLAY - len(credentialless_devices)
+        if remaining > 0:
+            for device in credentialless_firmwareless[:remaining]:
+                credentialless_devices.append(
+                    {
+                        "name": device.name,
+                        "url": reverse(
+                            f"admin:{device_app_label}_device_change",
+                            args=[device.pk],
+                        ),
+                    }
+                )
+        credentialless_more = max(0, total_credentialless - MAX_CREDENTIALLESS_DISPLAY)
         title = _("Confirm mass upgrade operation")
         context = self.admin_site.each_context(request)
         upgrader_schema = BatchUpgradeOperation(build=build)._get_upgrader_schema(
@@ -274,6 +314,9 @@ class BuildAdmin(BaseAdmin):
                 "related_count": len(related_device_fw),
                 "firmwareless_devices": firmwareless_devices,
                 "firmwareless_count": len(firmwareless_devices),
+                "credentialless_devices": credentialless_devices,
+                "credentialless_count": total_credentialless,
+                "credentialless_more": credentialless_more,
                 "form": form,
                 "firmware_upgrader_schema": json.dumps(
                     upgrader_schema, cls=DjangoJSONEncoder

--- a/openwisp_firmware_upgrader/base/models.py
+++ b/openwisp_firmware_upgrader/base/models.py
@@ -612,9 +612,13 @@ class AbstractBatchUpgradeOperation(UpgradeOptionsMixin, TimeStampedEditableMode
         upgrades all devices which have an
         existing related DeviceFirmware
         """
+        DeviceConnection = swapper.load_model("connection", "DeviceConnection")
+        valid_device_ids = DeviceConnection.objects.filter(
+            update_strategy__icontains="ssh", enabled=True
+        ).values("device_id")
         device_firmwares = self.build._find_related_device_firmwares(
             group=self.group, location=self.location
-        )
+        ).filter(device_id__in=valid_device_ids)
         for device_fw in device_firmwares:
             image = self.build.firmwareimage_set.filter(
                 type=device_fw.image.type
@@ -630,12 +634,16 @@ class AbstractBatchUpgradeOperation(UpgradeOptionsMixin, TimeStampedEditableMode
         have a related DeviceFirmware yet
         (referred as "firmwareless")
         """
+        DeviceConnection = swapper.load_model("connection", "DeviceConnection")
+        valid_device_ids = DeviceConnection.objects.filter(
+            update_strategy__icontains="ssh", enabled=True
+        ).values("device_id")
         # for each image, find related "firmwareless"
         # devices and perform upgrade one by one
         for image in self.build.firmwareimage_set.all():
             devices = self.build._find_firmwareless_devices(
                 image.boards, group=self.group, location=self.location
-            )
+            ).filter(pk__in=valid_device_ids)
             for device in devices:
                 DeviceFirmware = load_model("DeviceFirmware")
                 device_fw = DeviceFirmware(device=device, image=image)
@@ -693,18 +701,33 @@ class AbstractBatchUpgradeOperation(UpgradeOptionsMixin, TimeStampedEditableMode
 
     def _get_upgrader_class(self, related_device_fw=None, firmwareless_devices=None):
         if self.upgrade_operations:
-            return get_upgrader_class_for_device(self.upgrade_operations[0].device)
-        related_device_fw = (
-            related_device_fw
-            or self.build._find_related_device_firmwares(select_devices=True)
-        )
+            try:
+                return get_upgrader_class_for_device(self.upgrade_operations[0].device)
+            except ObjectDoesNotExist:
+                pass
+        DeviceConnection = swapper.load_model("connection", "DeviceConnection")
+        valid_device_ids = DeviceConnection.objects.filter(
+            update_strategy__icontains="ssh",
+            enabled=True,
+        ).values("device_id")
+        if related_device_fw is None:
+            related_device_fw = self.build._find_related_device_firmwares(
+                select_devices=True
+            )
         if related_device_fw:
-            return get_upgrader_class_for_device(related_device_fw.first().device)
-        firmwareless_devices = (
-            firmwareless_devices or self.build._find_firmwareless_devices()
-        )
+            df = (
+                related_device_fw.filter(device_id__in=valid_device_ids)
+                .select_related("device")
+                .first()
+            )
+            if df:
+                return get_upgrader_class_for_device(df.device)
+        if firmwareless_devices is None:
+            firmwareless_devices = self.build._find_firmwareless_devices()
         if firmwareless_devices:
-            return get_upgrader_class_for_device(firmwareless_devices.first())
+            device = firmwareless_devices.filter(pk__in=valid_device_ids).first()
+            if device:
+                return get_upgrader_class_for_device(device)
 
     def _get_upgrader_schema(self, related_device_fw=None, firmwareless_devices=None):
         upgrader_class = self._get_upgrader_class(

--- a/openwisp_firmware_upgrader/base/models.py
+++ b/openwisp_firmware_upgrader/base/models.py
@@ -169,10 +169,21 @@ class AbstractBuild(TimeStampedEditableModel):
         dry_run_result = load_model("BatchUpgradeOperation").dry_run(
             build=self, group=group, location=location
         )
+        # Filter out credentialless devices before checking if any remain
+        DeviceConnection = swapper.load_model("connection", "DeviceConnection")
+        valid_device_ids = DeviceConnection.objects.filter(
+            update_strategy__icontains="ssh", enabled=True
+        ).values("device_id")
+        upgradeable_device_firmwares = dry_run_result["device_firmwares"].filter(
+            device_id__in=valid_device_ids
+        )
+        upgradeable_firmwareless = dry_run_result["devices"].filter(
+            pk__in=valid_device_ids
+        )
         # If no devices match the filters, don't start the upgrade
         if not (
-            dry_run_result["device_firmwares"].exists()
-            or (firmwareless and dry_run_result["devices"].exists())
+            upgradeable_device_firmwares.exists()
+            or (firmwareless and upgradeable_firmwareless.exists())
         ):
             raise ValidationError(
                 _(
@@ -712,7 +723,7 @@ class AbstractBatchUpgradeOperation(UpgradeOptionsMixin, TimeStampedEditableMode
         ).values("device_id")
         if related_device_fw is None:
             related_device_fw = self.build._find_related_device_firmwares(
-                select_devices=True
+                select_devices=True, group=self.group, location=self.location
             )
         if related_device_fw:
             df = (
@@ -723,7 +734,9 @@ class AbstractBatchUpgradeOperation(UpgradeOptionsMixin, TimeStampedEditableMode
             if df:
                 return get_upgrader_class_for_device(df.device)
         if firmwareless_devices is None:
-            firmwareless_devices = self.build._find_firmwareless_devices()
+            firmwareless_devices = self.build._find_firmwareless_devices(
+                group=self.group, location=self.location
+            )
         if firmwareless_devices:
             device = firmwareless_devices.filter(pk__in=valid_device_ids).first()
             if device:

--- a/openwisp_firmware_upgrader/templates/admin/upgrade_selected_confirmation.html
+++ b/openwisp_firmware_upgrader/templates/admin/upgrade_selected_confirmation.html
@@ -21,6 +21,31 @@
 {% endblock %}
 
 {% block content %}
+  {% if credentialless_count %}
+    <div class="errornote">
+      <p>
+        {% blocktrans count count=credentialless_count %}
+          The following device cannot be upgraded because it has no SSH credentials assigned. Please assign credentials to proceed with the upgrade.
+        {% plural %}
+          The following {{ count }} devices cannot be upgraded because they have no SSH credentials assigned. Please assign credentials to proceed with the upgrade.
+        {% endblocktrans %}
+      </p>
+      <ul>
+        {% for device in credentialless_devices %}
+          <li><a href="{{ device.url }}">{{ device.name }}</a></li>
+        {% endfor %}
+      </ul>
+      {% if credentialless_more %}
+        <p>
+          {% blocktrans count count=credentialless_more %}
+            ... and {{ count }} more device without credentials (not shown).
+          {% plural %}
+            ... and {{ count }} more devices without credentials (not shown).
+          {% endblocktrans %}
+        </p>
+      {% endif %}
+    </div>
+  {% endif %}
   {% if related_count or firmwareless_count %}
     <p class="intro">
       {% blocktrans %}

--- a/openwisp_firmware_upgrader/templates/admin/upgrade_selected_confirmation.html
+++ b/openwisp_firmware_upgrader/templates/admin/upgrade_selected_confirmation.html
@@ -25,9 +25,9 @@
     <div class="errornote">
       <p>
         {% blocktrans count count=credentialless_count %}
-          The following device cannot be upgraded because it has no SSH credentials assigned. Please assign credentials to proceed with the upgrade.
+          The following device will be skipped because it has no SSH credentials assigned. The upgrade will proceed for the remaining devices. Assign credentials to include this device in future upgrades.
         {% plural %}
-          The following {{ count }} devices cannot be upgraded because they have no SSH credentials assigned. Please assign credentials to proceed with the upgrade.
+          The following {{ count }} devices will be skipped because they have no SSH credentials assigned. The upgrade will proceed for the remaining devices. Assign credentials to include them in future upgrades.
         {% endblocktrans %}
       </p>
       <ul>

--- a/openwisp_firmware_upgrader/tests/test_admin.py
+++ b/openwisp_firmware_upgrader/tests/test_admin.py
@@ -158,7 +158,7 @@ class TestAdmin(BaseTestAdmin, TestCase):
     def test_upgrade_intermediate_page_related(self):
         self._login()
         env = self._create_upgrade_env()
-        with self.assertNumQueries(15):
+        with self.assertNumQueries(21):
             r = self.client.post(
                 self.build_list_url,
                 {
@@ -172,7 +172,7 @@ class TestAdmin(BaseTestAdmin, TestCase):
     def test_upgrade_intermediate_page_firmwareless(self):
         self._login()
         env = self._create_upgrade_env(device_firmware=False)
-        with self.assertNumQueries(14):
+        with self.assertNumQueries(18):
             r = self.client.post(
                 self.build_list_url,
                 {
@@ -186,6 +186,116 @@ class TestAdmin(BaseTestAdmin, TestCase):
             'name="upgrade_related"',
         )
         self.assertContains(r, 'name="upgrade_all"')
+
+    def test_upgrade_intermediate_page_credentialless_related(self):
+        self._login()
+        env = self._create_upgrade_env()
+        # Remove SSH credentials from one device
+        env["d1"].deviceconnection_set.all().delete()
+        r = self.client.post(
+            self.build_list_url,
+            {
+                "action": "upgrade_selected",
+                ACTION_CHECKBOX_NAME: (env["build2"].pk,),
+            },
+            follow=True,
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertContains(r, "no SSH credentials assigned")
+        device_url = reverse(
+            f"admin:{self.config_app_label}_device_change", args=[env["d1"].pk]
+        )
+        self.assertContains(r, f'href="{device_url}"')
+        self.assertContains(r, env["d1"].name)
+
+    def test_upgrade_intermediate_page_credentialless_firmwareless(self):
+        self._login()
+        env = self._create_upgrade_env(device_firmware=False)
+        # Remove SSH credentials from one device
+        env["d1"].deviceconnection_set.all().delete()
+        r = self.client.post(
+            self.build_list_url,
+            {
+                "action": "upgrade_selected",
+                ACTION_CHECKBOX_NAME: (env["build2"].pk,),
+            },
+            follow=True,
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertContains(r, "no SSH credentials assigned")
+        device_url = reverse(
+            f"admin:{self.config_app_label}_device_change", args=[env["d1"].pk]
+        )
+        self.assertContains(r, f'href="{device_url}"')
+        self.assertContains(r, env["d1"].name)
+
+    def test_upgrade_intermediate_page_all_credentialless(self):
+        # If ALL devices lack credentials the page must not 500
+        self._login()
+        env = self._create_upgrade_env()
+        env["d1"].deviceconnection_set.all().delete()
+        env["d2"].deviceconnection_set.all().delete()
+        r = self.client.post(
+            self.build_list_url,
+            {
+                "action": "upgrade_selected",
+                ACTION_CHECKBOX_NAME: (env["build2"].pk,),
+            },
+            follow=True,
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertContains(r, "no SSH credentials assigned")
+
+    def test_upgrade_intermediate_page_credentialless_more_than_max(self):
+        from openwisp_firmware_upgrader.admin import MAX_CREDENTIALLESS_DISPLAY
+
+        self._login()
+        org = self._get_org()
+        category = self._get_category(organization=org)
+        build1 = self._create_build(category=category, version="0.1")
+        build2 = self._create_build(category=category, version="0.2")
+        image1 = self._create_firmware_image(build=build1, type=self.TPLINK_4300_IMAGE)
+        self._create_firmware_image(build=build2, type=self.TPLINK_4300_IMAGE)
+        # Create more devices than the display limit
+        # Each device gets a connection first (required for full_clean),
+        # then the connection is removed to simulate credentialless state.
+        ssh_credentials = self._get_credentials(organization=None)
+        devices = []
+        for i in range(MAX_CREDENTIALLESS_DISPLAY + 2):
+            mac = f"00:11:22:33:44:{i:02x}"
+            d = self._create_device(
+                name=f"nocreds-device-{i}",
+                organization=org,
+                mac_address=mac,
+                model=image1.boards[0],
+            )
+            self._create_config(device=d)
+            self._create_device_connection(device=d, credentials=ssh_credentials)
+            self._create_device_firmware(
+                device=d, image=image1, device_connection=False
+            )
+            d.deviceconnection_set.all().delete()
+            devices.append(d)
+        r = self.client.post(
+            self.build_list_url,
+            {
+                "action": "upgrade_selected",
+                ACTION_CHECKBOX_NAME: (build2.pk,),
+            },
+            follow=True,
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertContains(r, "no SSH credentials assigned")
+        self.assertContains(r, "more device")
+        self.assertContains(r, "without credentials")
+        total_credentialless = MAX_CREDENTIALLESS_DISPLAY + 2
+        self.assertEqual(
+            len(r.context["credentialless_devices"]), MAX_CREDENTIALLESS_DISPLAY
+        )
+        self.assertEqual(
+            r.context["credentialless_more"],
+            total_credentialless - MAX_CREDENTIALLESS_DISPLAY,
+        )
 
     def test_view_device_administrator(self):
         device_fw = self._create_device_firmware()


### PR DESCRIPTION
## Problem

When triggering a mass firmware upgrade, if any device (or all devices) lacked a `DeviceConnection` with SSH credentials, `_get_upgrader_class()` would call `get_upgrader_class_for_device()` on an uncredentialed device, raising an unhandled `DoesNotExist` and returning a 500 error.

Additionally, there was no UI feedback to inform administrators which devices would be skipped due to missing credentials.

## Changes

### `base/models.py` — `_get_upgrader_class()`
- Wraps the `upgrade_operations` path in `try/except ObjectDoesNotExist`
- Uses an ORM subquery to find the **first device with a valid SSH credential** from both `related_device_fw` and `firmwareless_devices`, instead of blindly using the first device regardless of credentials

### `admin.py` — `upgrade_selected()`
- After `dry_run()`, identifies devices without valid SSH credentials from both querysets using ORM exclusion
- Builds a list of up to `MAX_CREDENTIALLESS_DISPLAY` (5) devices with their admin change URLs
- Calculates overflow count (`credentialless_more`) for the "and N more" message
- Passes `credentialless_devices`, `credentialless_count`, and `credentialless_more` to the template context

### `templates/admin/upgrade_selected_confirmation.html`
- New `errornote` warning block shown when `credentialless_count > 0`
- Lists each credentialless device as a clickable admin link
- Shows "... and N more device(s) without credentials (not shown)." when the list is truncated

### `tests/test_admin.py`
- `test_upgrade_intermediate_page_credentialless_related` — credentialless device in related DeviceFirmware
- `test_upgrade_intermediate_page_credentialless_firmwareless` — credentialless firmwareless device
- `test_upgrade_intermediate_page_all_credentialless` — all devices lack credentials, no 500
- `test_upgrade_intermediate_page_credentialless_more_than_max` — overflow beyond display limit triggers "and N more"

## Fixes

Fixes #302