### PR TITLE
[fix] Remove invalid escape sequence warnings in OpenWrt strings

### DIFF
--- a/openwisp_firmware_upgrader/tests/test_openwrt_upgrader.py
+++ b/openwisp_firmware_upgrader/tests/test_openwrt_upgrader.py
@@ -192,10 +192,10 @@ def mocked_exec_upgrade_success_false_positives(
         filename = command.split()[-1].split("/")[-1]
         raise CommandFailedException(
             "Command failed: ubus call system sysupgrade "
-            '{ "prefix": "\/tmp\/root", '
-            f'"path": "\/tmp\/{filename}", '
-            '"backup": "\/tmp\/sysupgrade.tgz", '
-            '"command": "\/lib\/upgrade\/do_stage2", '
+            '{ "prefix": "/tmp/root", '
+            f'"path": "/tmp/{filename}", '
+            '"backup": "/tmp/sysupgrade.tgz", '
+            '"command": "/lib/upgrade/do_stage2", '
             '"options": { "save_partitions": 1 } } '
             "(Connection failed)"
         )

--- a/openwisp_firmware_upgrader/upgraders/openwrt.py
+++ b/openwisp_firmware_upgrader/upgraders/openwrt.py
@@ -91,14 +91,14 @@ class OpenWrt(object):
 
     _false_positives = [
         "Command failed: ubus call system sysupgrade "
-        '\{ "prefix": "\\\/tmp\\\/root", "path": "[^"]*", '
-        '"backup": "\\\/tmp\\\/sysupgrade.tgz", '
-        '"command": "\\\/lib\\\/upgrade\\\/do_stage2", '
-        '"options": \{ "save_partitions": 1 \} \}',
+        r'\{ "prefix": "\\?/tmp\\?/root", "path": "[^"]*", '
+        r'"backup": "\\?/tmp\\?/sysupgrade.tgz", '
+        r'"command": "\\?/lib\\?/upgrade\\?/do_stage2", '
+        r'"options": \{ "save_partitions": 1 \} \}',
         "Command failed: ubus call system sysupgrade "
-        '\{ "prefix": "\\\/tmp\\\/root", "path": "[^"]*", '
-        '"command": "\\\/lib\\\/upgrade\\\/do_stage2", '
-        '"options": \{ "save_partitions": 1 \} \}',
+        r'\{ "prefix": "\\?/tmp\\?/root", "path": "[^"]*", '
+        r'"command": "\\?/lib\\?/upgrade\\?/do_stage2", '
+        r'"options": \{ "save_partitions": 1 \} \}',
     ]
 
     def __init__(self, upgrade_operation, connection):


### PR DESCRIPTION
Summary
This PR removes Python 3.12+ SyntaxWarning: invalid escape sequence warnings in OpenWrt upgrader false-positive patterns and related test fixture strings.

Why
These warnings appear in CI output and local runs, adding noise and making warning-related regressions harder to spot.

Changes
- Use raw string literals for regex-like patterns in openwisp_firmware_upgrader/upgraders/openwrt.py.
- Replace unnecessary escaped forward slashes in openwisp_firmware_upgrader/tests/test_openwrt_upgrader.py test message fixtures.

Behavior impact
No functional behavior change is intended. This is a warning/housekeeping cleanup.

Validation
- Reproduced warnings before fix:
  - python3 -W default -m py_compile openwisp_firmware_upgrader/upgraders/openwrt.py openwisp_firmware_upgrader/tests/test_openwrt_upgrader.py
- Verified clean after fix:
  - python3 -W error::SyntaxWarning -m py_compile openwisp_firmware_upgrader/upgraders/openwrt.py openwisp_firmware_upgrader/tests/test_openwrt_upgrader.py

Checklist
- [x] I have read the OpenWISP Contributing Guidelines.
- [x] I have manually verified the change.
- [x] I have updated tests where needed.
- [x] I have updated documentation (not needed for this housekeeping fix).