### PR TITLE
[fix] Remove invalid escape sequence warnings in OpenWrt strings

### DIFF
--- a/openwisp_firmware_upgrader/tests/test_openwrt_upgrader.py
+++ b/openwisp_firmware_upgrader/tests/test_openwrt_upgrader.py
@@ -192,10 +192,10 @@ def mocked_exec_upgrade_success_false_positives(
         filename = command.split()[-1].split("/")[-1]
         raise CommandFailedException(
             "Command failed: ubus call system sysupgrade "
-            '{ "prefix": "\/tmp\/root", '
-            f'"path": "\/tmp\/{filename}", '
-            '"backup": "\/tmp\/sysupgrade.tgz", '
-            '"command": "\/lib\/upgrade\/do_stage2", '
+            '{ "prefix": "/tmp/root", '
+            f'"path": "/tmp/{filename}", '
+            '"backup": "/tmp/sysupgrade.tgz", '
+            '"command": "/lib/upgrade/do_stage2", '
             '"options": { "save_partitions": 1 } } '
             "(Connection failed)"
         )

--- a/openwisp_firmware_upgrader/upgraders/openwrt.py
+++ b/openwisp_firmware_upgrader/upgraders/openwrt.py
@@ -91,14 +91,14 @@ class OpenWrt(object):
 
     _false_positives = [
         "Command failed: ubus call system sysupgrade "
-        '\{ "prefix": "\\\/tmp\\\/root", "path": "[^"]*", '
-        '"backup": "\\\/tmp\\\/sysupgrade.tgz", '
-        '"command": "\\\/lib\\\/upgrade\\\/do_stage2", '
-        '"options": \{ "save_partitions": 1 \} \}',
+        r'\{ "prefix": "\\?/tmp\\?/root", "path": "[^"]*", '
+        r'"backup": "\\?/tmp\\?/sysupgrade.tgz", '
+        r'"command": "\\?/lib\\?/upgrade\\?/do_stage2", '
+        r'"options": \{ "save_partitions": 1 \} \}',
         "Command failed: ubus call system sysupgrade "
-        '\{ "prefix": "\\\/tmp\\\/root", "path": "[^"]*", '
-        '"command": "\\\/lib\\\/upgrade\\\/do_stage2", '
-        '"options": \{ "save_partitions": 1 \} \}',
+        r'\{ "prefix": "\\?/tmp\\?/root", "path": "[^"]*", '
+        r'"command": "\\?/lib\\?/upgrade\\?/do_stage2", '
+        r'"options": \{ "save_partitions": 1 \} \}',
     ]
 
     def __init__(self, upgrade_operation, connection):


### PR DESCRIPTION
Summary
This PR removes Python 3.12+ invalid escape sequence SyntaxWarnings in OpenWrt upgrader/test strings.

Changes
- Converted OpenWrt false-positive regex patterns to raw strings to avoid invalid escape warnings.
- Updated false-positive regex patterns to match both escaped and unescaped path variants (e.g. \/tmp and /tmp), preserving intended suppression behavior.
- Simplified OpenWrt test fixture strings by removing unnecessary escaped forward slashes.

Behavior impact
No intended functional behavior change beyond keeping false-positive matching robust across escaped/unescaped log formats.

Validation
- Before (warnings reproduced):
  - python3 -W default -m py_compile openwisp_firmware_upgrader/upgraders/openwrt.py openwisp_firmware_upgrader/tests/test_openwrt_upgrader.py
- After (clean):
  - python3 -W error::SyntaxWarning -m py_compile openwisp_firmware_upgrader/upgraders/openwrt.py openwisp_firmware_upgrader/tests/test_openwrt_upgrader.py

Checklist
- [x] Read contributing guidelines.
- [x] Manually validated changes.
- [x] Updated test fixtures as needed.
- [ ] Documentation update not needed for this housekeeping fix.