### PR TITLE
[fix] Prevent HTTP 500 on missing device credentials

### DIFF
--- a/openwisp_firmware_upgrader/admin.py
+++ b/openwisp_firmware_upgrader/admin.py
@@ -668,7 +668,21 @@ class DeviceFirmwareForm(forms.ModelForm):
             device, device_firmware=self.instance
         )
 
+    def _has_credentials_in_form(self):
+        if not self.data:
+            return False
+        total = int(self.data.get("deviceconnection_set-TOTAL_FORMS", 0))
+        for i in range(total):
+            prefix = f"deviceconnection_set-{i}"
+            has_cred = self.data.get(f"{prefix}-credentials")
+            is_deleted = self.data.get(f"{prefix}-DELETE")
+            if has_cred and not is_deleted:
+                return True
+        return False
+
     def full_clean(self):
+        if self._has_credentials_in_form():
+            self.instance._skip_connection_check = True
         super().full_clean()
         if not self.is_bound:
             return

--- a/openwisp_firmware_upgrader/admin.py
+++ b/openwisp_firmware_upgrader/admin.py
@@ -671,7 +671,10 @@ class DeviceFirmwareForm(forms.ModelForm):
     def _has_credentials_in_form(self):
         if not self.data:
             return False
-        total = int(self.data.get("deviceconnection_set-TOTAL_FORMS", 0))
+        try:
+            total = int(self.data.get("deviceconnection_set-TOTAL_FORMS", 0))
+        except (TypeError, ValueError):
+            return False
         for i in range(total):
             prefix = f"deviceconnection_set-{i}"
             has_cred = self.data.get(f"{prefix}-credentials")

--- a/openwisp_firmware_upgrader/base/models.py
+++ b/openwisp_firmware_upgrader/base/models.py
@@ -1012,6 +1012,11 @@ class AbstractUpgradeOperation(UpgradeOptionsMixin, TimeStampedEditableModel):
             self.device.devicefirmware.installed = True
             self.device.devicefirmware.save(upgrade=False)
 
+    def validate_upgrade_options(self):
+        if not self._state.adding:
+            return
+        super().validate_upgrade_options()
+
     def save(self, *args, **kwargs):
         super().save(*args, **kwargs)
         # when an operation is completed

--- a/openwisp_firmware_upgrader/base/models.py
+++ b/openwisp_firmware_upgrader/base/models.py
@@ -409,7 +409,7 @@ class AbstractDeviceFirmware(TimeStampedEditableModel):
                     )
                 }
             )
-        if self.device.deviceconnection_set.count() < 1:
+        if self.image_has_changed and self.device.deviceconnection_set.count() < 1:
             raise ValidationError(
                 _(
                     "This device does not have a related connection object defined "

--- a/openwisp_firmware_upgrader/base/models.py
+++ b/openwisp_firmware_upgrader/base/models.py
@@ -1024,6 +1024,19 @@ class AbstractUpgradeOperation(UpgradeOptionsMixin, TimeStampedEditableModel):
             self.device.devicefirmware.installed = True
             self.device.devicefirmware.save(upgrade=False)
 
+    def validate_upgrade_options(self):
+        """Validate options only for new upgrade operations.
+
+        Pre-existing upgrade operations are readonly, but validation of relationship
+        can become complex and generate a lot of edge cases, in order to keep things
+        simple this validation step is skipped for pre-existing objects.
+        """
+        try:
+            super().validate_upgrade_options()
+        except ValidationError:
+            if self._state.adding:
+                raise
+
     def save(self, *args, **kwargs):
         super().save(*args, **kwargs)
         # when an operation is completed

--- a/openwisp_firmware_upgrader/base/models.py
+++ b/openwisp_firmware_upgrader/base/models.py
@@ -409,7 +409,11 @@ class AbstractDeviceFirmware(TimeStampedEditableModel):
                     )
                 }
             )
-        if self.image_has_changed and self.device.deviceconnection_set.count() < 1:
+        if (
+            self.image_has_changed
+            and not getattr(self, "_skip_connection_check", False)
+            and self.device.deviceconnection_set.count() < 1
+        ):
             raise ValidationError(
                 _(
                     "This device does not have a related connection object defined "

--- a/openwisp_firmware_upgrader/base/models.py
+++ b/openwisp_firmware_upgrader/base/models.py
@@ -67,7 +67,7 @@ class UpgradeOptionsMixin(models.Model):
             raise ValidationError(
                 _("No related connection or credentials found for this device.")
             )
-        if not getattr(upgrader_class, "SCHEMA", None):
+        if not getattr(upgrader_class, "SCHEMA"):
             raise ValidationError(
                 _("Using upgrade options is not allowed with this upgrader.")
             )
@@ -409,9 +409,16 @@ class AbstractDeviceFirmware(TimeStampedEditableModel):
                     )
                 }
             )
+        # When an admin adds credentials and changes the firmware image in the
+        # same save, the new credentials haven't been persisted yet at the time
+        # this check runs, so without `_skip_connection_check` the form would
+        # wrongly reject the change with "please add credentials".
+        # `DeviceFirmwareForm` sets the flag when it sees credentials in the
+        # submitted data.
+        skip_connection_check = getattr(self, "_skip_connection_check", False)
         if (
             self.image_has_changed
-            and not getattr(self, "_skip_connection_check", False)
+            and not skip_connection_check
             and self.device.deviceconnection_set.count() < 1
         ):
             raise ValidationError(
@@ -1015,13 +1022,6 @@ class AbstractUpgradeOperation(UpgradeOptionsMixin, TimeStampedEditableModel):
         if installed:
             self.device.devicefirmware.installed = True
             self.device.devicefirmware.save(upgrade=False)
-
-    def validate_upgrade_options(self):
-        try:
-            super().validate_upgrade_options()
-        except ValidationError:
-            if self._state.adding:
-                raise
 
     def save(self, *args, **kwargs):
         super().save(*args, **kwargs)

--- a/openwisp_firmware_upgrader/base/models.py
+++ b/openwisp_firmware_upgrader/base/models.py
@@ -416,8 +416,9 @@ class AbstractDeviceFirmware(TimeStampedEditableModel):
         # `DeviceFirmwareForm` sets the flag when it sees credentials in the
         # submitted data.
         skip_connection_check = getattr(self, "_skip_connection_check", False)
+        will_start_upgrade = self.image_has_changed or not self.installed
         if (
-            self.image_has_changed
+            will_start_upgrade
             and not skip_connection_check
             and self.device.deviceconnection_set.count() < 1
         ):

--- a/openwisp_firmware_upgrader/base/models.py
+++ b/openwisp_firmware_upgrader/base/models.py
@@ -1017,9 +1017,11 @@ class AbstractUpgradeOperation(UpgradeOptionsMixin, TimeStampedEditableModel):
             self.device.devicefirmware.save(upgrade=False)
 
     def validate_upgrade_options(self):
-        if not self._state.adding:
-            return
-        super().validate_upgrade_options()
+        try:
+            super().validate_upgrade_options()
+        except ValidationError:
+            if self._state.adding:
+                raise
 
     def save(self, *args, **kwargs):
         super().save(*args, **kwargs)

--- a/openwisp_firmware_upgrader/base/models.py
+++ b/openwisp_firmware_upgrader/base/models.py
@@ -61,12 +61,18 @@ class UpgradeOptionsMixin(models.Model):
     def validate_upgrade_options(self):
         if not self.upgrade_options:
             return
-        if not getattr(self.upgrader_class, "SCHEMA"):
+        try:
+            upgrader_class = self.upgrader_class
+        except ObjectDoesNotExist:
+            raise ValidationError(
+                _("No related connection or credentials found for this device.")
+            )
+        if not getattr(upgrader_class, "SCHEMA", None):
             raise ValidationError(
                 _("Using upgrade options is not allowed with this upgrader.")
             )
         try:
-            self.upgrader_class.validate_upgrade_options(self.upgrade_options)
+            upgrader_class.validate_upgrade_options(self.upgrade_options)
         except jsonschema.ValidationError:
             raise ValidationError("The upgrade options are invalid")
         except FirmwareUpgradeOptionsException as error:

--- a/openwisp_firmware_upgrader/tests/test_admin.py
+++ b/openwisp_firmware_upgrader/tests/test_admin.py
@@ -397,7 +397,7 @@ class TestAdmin(BaseTestAdmin, TestCase):
     def test_save_device_after_credentials_deleted(self, *args):
         """Regression test for #250."""
         self._login()
-        device_fw = self._create_device_firmware()
+        device_fw = self._create_device_firmware(installed=True)
         device = device_fw.device
         device_conn = device.deviceconnection_set.first()
         device_params = self._get_device_params(

--- a/openwisp_firmware_upgrader/tests/test_admin.py
+++ b/openwisp_firmware_upgrader/tests/test_admin.py
@@ -394,6 +394,73 @@ class TestAdmin(BaseTestAdmin, TestCase):
         mocked_func.assert_not_called()
         self.assertEqual(response.status_code, 200)
 
+    def test_save_device_after_credentials_deleted(self, *args):
+        """Regression test for #250."""
+        self._login()
+        device_fw = self._create_device_firmware()
+        device = device_fw.device
+        device_conn = device.deviceconnection_set.first()
+        device_params = self._get_device_params(
+            device, device_conn, device_fw.image, device_fw
+        )
+        # delete credentials
+        device.deviceconnection_set.all().delete()
+        # remove connection data from form (simulates deleted inline)
+        device_params["deviceconnection_set-TOTAL_FORMS"] = 0
+        device_params["deviceconnection_set-INITIAL_FORMS"] = 0
+        del device_params["deviceconnection_set-0-credentials"]
+        del device_params["deviceconnection_set-0-id"]
+        del device_params["deviceconnection_set-0-update_strategy"]
+        del device_params["deviceconnection_set-0-enabled"]
+        # save device without changing image — should succeed
+        response = self.client.post(
+            reverse(f"admin:{self.config_app_label}_device_change", args=[device.id]),
+            data=device_params,
+            follow=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "Please correct the error")
+
+    def test_change_image_and_add_credentials_together(self, *args):
+        """Regression test for #250."""
+        self._login()
+        device_fw = self._create_device_firmware()
+        device = device_fw.device
+        device_conn = device.deviceconnection_set.first()
+        credentials_id = device_conn.credentials_id
+        update_strategy = device_conn.update_strategy
+        # create a new image to switch to
+        build = self._create_build(version="0.2")
+        new_image = self._create_firmware_image(build=build)
+        # delete existing connection
+        device.deviceconnection_set.all().delete()
+        # build form data: new image + new credentials in same submit
+        device_params = self._get_device_params(
+            device, device_conn, new_image, device_fw
+        )
+        device_params.update(
+            {
+                "devicefirmware-0-image": str(new_image.id),
+                "deviceconnection_set-TOTAL_FORMS": 1,
+                "deviceconnection_set-INITIAL_FORMS": 0,
+                "deviceconnection_set-0-credentials": str(credentials_id),
+                "deviceconnection_set-0-update_strategy": update_strategy,
+                "deviceconnection_set-0-enabled": True,
+            }
+        )
+        if "deviceconnection_set-0-id" in device_params:
+            del device_params["deviceconnection_set-0-id"]
+        response = self.client.post(
+            reverse(f"admin:{self.config_app_label}_device_change", args=[device.id]),
+            data=device_params,
+            follow=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "Please correct the error")
+        device_fw.refresh_from_db()
+        self.assertEqual(device_fw.image, new_image)
+        self.assertEqual(device.deviceconnection_set.count(), 1)
+
     def test_deactivated_firmware_image_inline(self):
         self._login()
         device = self._create_config(organization=self._get_org()).device

--- a/openwisp_firmware_upgrader/tests/test_admin.py
+++ b/openwisp_firmware_upgrader/tests/test_admin.py
@@ -403,16 +403,13 @@ class TestAdmin(BaseTestAdmin, TestCase):
         device_params = self._get_device_params(
             device, device_conn, device_fw.image, device_fw
         )
-        # delete credentials
         device.deviceconnection_set.all().delete()
-        # remove connection data from form (simulates deleted inline)
         device_params["deviceconnection_set-TOTAL_FORMS"] = 0
         device_params["deviceconnection_set-INITIAL_FORMS"] = 0
         del device_params["deviceconnection_set-0-credentials"]
         del device_params["deviceconnection_set-0-id"]
         del device_params["deviceconnection_set-0-update_strategy"]
         del device_params["deviceconnection_set-0-enabled"]
-        # save device without changing image — should succeed
         response = self.client.post(
             reverse(f"admin:{self.config_app_label}_device_change", args=[device.id]),
             data=device_params,

--- a/openwisp_firmware_upgrader/tests/test_admin.py
+++ b/openwisp_firmware_upgrader/tests/test_admin.py
@@ -459,6 +459,72 @@ class TestAdmin(BaseTestAdmin, TestCase):
         self.assertEqual(device_fw.image, new_image)
         self.assertEqual(device.deviceconnection_set.count(), 1)
 
+    def test_add_credentials_with_cancelled_upgrade_operation(self, *args):
+        """Regression test for adding credentials while a cancelled upgrade is shown."""
+        with mock.patch(
+            "openwisp_controller.connection.models.DeviceConnection.connect",
+            return_value=True,
+        ), mock.patch(
+            "openwisp_firmware_upgrader.upgraders.openwrt.OpenWrt.upgrade",
+            return_value=True,
+        ):
+            self._login()
+            device = self._create_config(organization=self._get_org()).device
+            device_conn = self._create_device_connection(device=device)
+            credentials_id = device_conn.credentials_id
+            update_strategy = device_conn.update_strategy
+            image = self._create_firmware_image(organization=device.organization)
+            device_params = self._get_device_params(
+                device,
+                device_conn,
+                image,
+                upgrade_options=json.dumps({"c": True}),
+            )
+            response = self.client.post(
+                reverse(
+                    f"admin:{self.config_app_label}_device_change", args=[device.id]
+                ),
+                data=device_params,
+                follow=True,
+            )
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(device.upgradeoperation_set.count(), 1)
+            # cancel upgrade operation and remove DeviceConnection object
+            upgrade_operation = device.upgradeoperation_set.get()
+            upgrade_operation.cancel()
+            device_fw = device.devicefirmware
+            device.deviceconnection_set.all().delete()
+            # submit form creating a new credential
+            device_params = self._get_device_params(
+                device, device_conn, image, device_fw
+            )
+            device_params.update(
+                {
+                    "deviceconnection_set-TOTAL_FORMS": 1,
+                    "deviceconnection_set-INITIAL_FORMS": 0,
+                    "deviceconnection_set-0-credentials": str(credentials_id),
+                    "deviceconnection_set-0-update_strategy": update_strategy,
+                    "deviceconnection_set-0-enabled": True,
+                    "upgradeoperation_set-TOTAL_FORMS": 1,
+                    "upgradeoperation_set-INITIAL_FORMS": 1,
+                    "upgradeoperation_set-0-id": str(upgrade_operation.id),
+                    "upgradeoperation_set-0-device": str(device.id),
+                }
+            )
+            del device_params["deviceconnection_set-0-id"]
+            response = self.client.post(
+                reverse(
+                    f"admin:{self.config_app_label}_device_change", args=[device.id]
+                ),
+                data=device_params,
+                follow=True,
+            )
+            self.assertEqual(response.status_code, 200)
+            self.assertNotContains(
+                response, "No related connection or credentials found for this device."
+            )
+            self.assertEqual(device.deviceconnection_set.count(), 1)
+
     def test_deactivated_firmware_image_inline(self):
         self._login()
         device = self._create_config(organization=self._get_org()).device

--- a/openwisp_firmware_upgrader/tests/test_admin.py
+++ b/openwisp_firmware_upgrader/tests/test_admin.py
@@ -445,8 +445,9 @@ class TestAdmin(BaseTestAdmin, TestCase):
                 "deviceconnection_set-0-enabled": True,
             }
         )
-        if "deviceconnection_set-0-id" in device_params:
-            del device_params["deviceconnection_set-0-id"]
+        # `_get_device_params` populated `-0-id` from the now-deleted connection;
+        # with INITIAL_FORMS=0 the formset must treat row 0 as new, not as an edit.
+        del device_params["deviceconnection_set-0-id"]
         response = self.client.post(
             reverse(f"admin:{self.config_app_label}_device_change", args=[device.id]),
             data=device_params,

--- a/openwisp_firmware_upgrader/tests/test_api.py
+++ b/openwisp_firmware_upgrader/tests/test_api.py
@@ -1309,7 +1309,7 @@ class TestDeviceFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
 
         with self.subTest("Test device and image model validation"):
             url = reverse("upgrader:api_devicefirmware_detail", args=[device1.pk])
-            with self.assertNumQueries(18):
+            with self.assertNumQueries(17):
                 # Try to make a request when the
                 # device model does not match the image model
                 data = {"image": image1a.pk}
@@ -1490,7 +1490,7 @@ class TestDeviceFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
         self.assertEqual(DeviceFirmware.objects.count(), 2)
         self.assertEqual(UpgradeOperation.objects.count(), 0)
 
-        with self.assertNumQueries(27):
+        with self.assertNumQueries(26):
             data = {"image": image2a.pk}
             r = self.client.put(
                 f"{url}?format=api", data, content_type="application/json"
@@ -1529,7 +1529,7 @@ class TestDeviceFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
         self.assertEqual(DeviceFirmware.objects.count(), 2)
         self.assertEqual(UpgradeOperation.objects.count(), 0)
 
-        with self.assertNumQueries(27):
+        with self.assertNumQueries(26):
             data = {"image": image2a.pk}
             r = self.client.patch(
                 f"{url}?format=api", data, content_type="application/json"

--- a/openwisp_firmware_upgrader/tests/test_api.py
+++ b/openwisp_firmware_upgrader/tests/test_api.py
@@ -1309,7 +1309,7 @@ class TestDeviceFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
 
         with self.subTest("Test device and image model validation"):
             url = reverse("upgrader:api_devicefirmware_detail", args=[device1.pk])
-            with self.assertNumQueries(17):
+            with self.assertNumQueries(18):
                 # Try to make a request when the
                 # device model does not match the image model
                 data = {"image": image1a.pk}
@@ -1490,7 +1490,7 @@ class TestDeviceFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
         self.assertEqual(DeviceFirmware.objects.count(), 2)
         self.assertEqual(UpgradeOperation.objects.count(), 0)
 
-        with self.assertNumQueries(26):
+        with self.assertNumQueries(27):
             data = {"image": image2a.pk}
             r = self.client.put(
                 f"{url}?format=api", data, content_type="application/json"
@@ -1529,7 +1529,7 @@ class TestDeviceFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
         self.assertEqual(DeviceFirmware.objects.count(), 2)
         self.assertEqual(UpgradeOperation.objects.count(), 0)
 
-        with self.assertNumQueries(26):
+        with self.assertNumQueries(27):
             data = {"image": image2a.pk}
             r = self.client.patch(
                 f"{url}?format=api", data, content_type="application/json"

--- a/openwisp_firmware_upgrader/tests/test_models.py
+++ b/openwisp_firmware_upgrader/tests/test_models.py
@@ -179,12 +179,20 @@ class TestModels(TestUpgraderMixin, TestCase):
 
     def test_device_fw_save_after_credentials_removed(self):
         """Regression test for #250."""
-        device_fw = self._create_device_firmware()
+        device_fw = self._create_device_firmware(installed=True)
         device_fw.device.deviceconnection_set.all().delete()
         device_fw.full_clean()
         uo_count = UpgradeOperation.objects.count()
         device_fw.save(upgrade=False)
         self.assertEqual(UpgradeOperation.objects.count(), uo_count)
+
+    def test_device_fw_uninstalled_without_credentials_rejected(self):
+        """Reject saves that would start an upgrade with no credentials."""
+        device_fw = self._create_device_firmware(installed=False)
+        device_fw.device.deviceconnection_set.all().delete()
+        with self.assertRaises(ValidationError) as ctx:
+            device_fw.full_clean()
+        self.assertIn("related connection", str(ctx.exception))
 
     def test_invalid_board(self):
         image = FIRMWARE_IMAGE_MAP[self.TPLINK_4300_IMAGE]

--- a/openwisp_firmware_upgrader/tests/test_models.py
+++ b/openwisp_firmware_upgrader/tests/test_models.py
@@ -177,6 +177,15 @@ class TestModels(TestUpgraderMixin, TestCase):
         else:
             self.fail("ValidationError not raised")
 
+    def test_device_fw_credentials_removed_after_assignment(self):
+        """Regression test for #250."""
+        device_fw = self._create_device_firmware()
+        device_fw.upgrade_options = {"n": True}
+        device_fw.device.deviceconnection_set.all().delete()
+        with self.assertRaises(ValidationError) as ctx:
+            device_fw.full_clean()
+        self.assertIn("connection", str(ctx.exception).lower())
+
     def test_invalid_board(self):
         image = FIRMWARE_IMAGE_MAP[self.TPLINK_4300_IMAGE]
         boards = image["boards"]
@@ -242,6 +251,20 @@ class TestModels(TestUpgraderMixin, TestCase):
                 error.exception.message_dict["upgrade_options"],
                 ['The "-n" and "-o" options cannot be used together'],
             )
+
+    def test_upgrade_operation_credentials_removed(self):
+        """Regression test for #250."""
+        device_fw = self._create_device_firmware()
+        device = device_fw.device
+        uo = UpgradeOperation(
+            device=device,
+            image=device_fw.image,
+            upgrade_options={"n": True},
+        )
+        device.deviceconnection_set.all().delete()
+        with self.assertRaises(ValidationError) as ctx:
+            uo.full_clean()
+        self.assertIn("connection", str(ctx.exception).lower())
 
     def test_upgrade_operation_log_line(self):
         device_fw = self._create_device_firmware()

--- a/openwisp_firmware_upgrader/tests/test_models.py
+++ b/openwisp_firmware_upgrader/tests/test_models.py
@@ -177,14 +177,14 @@ class TestModels(TestUpgraderMixin, TestCase):
         else:
             self.fail("ValidationError not raised")
 
-    def test_device_fw_credentials_removed_after_assignment(self):
+    def test_device_fw_save_after_credentials_removed(self):
         """Regression test for #250."""
         device_fw = self._create_device_firmware()
-        device_fw.upgrade_options = {"n": True}
         device_fw.device.deviceconnection_set.all().delete()
-        with self.assertRaises(ValidationError) as ctx:
-            device_fw.full_clean()
-        self.assertIn("connection", str(ctx.exception).lower())
+        device_fw.full_clean()
+        uo_count = UpgradeOperation.objects.count()
+        device_fw.save(upgrade=False)
+        self.assertEqual(UpgradeOperation.objects.count(), uo_count)
 
     def test_invalid_board(self):
         image = FIRMWARE_IMAGE_MAP[self.TPLINK_4300_IMAGE]


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #250

## Description of Changes

When device credentials are deleted after a firmware image is assigned, saving the device form crashes with HTTP 500 because `validate_upgrade_options()` calls `self.upgrader_class` which raises `DoesNotExist` (unhandled).
This PR catches `ObjectDoesNotExist` and raises a `ValidationError` instead, so the admin shows a proper error message.Also adds `getattr` default to prevent potential `AttributeError` on `SCHEMA`.
