### PR TITLE
[change] Allow deletion of completed upgrade operations

### DIFF
--- a/docs/user/upgrade-status.rst
+++ b/docs/user/upgrade-status.rst
@@ -191,17 +191,18 @@ Upgrade operations and batch upgrade operations can be deleted from the
 admin interface only after they leave the ``in-progress`` state.
 
 Deleting an operation while it is still running is intentionally blocked
-because the upgrade may be uploading or flashing a firmware image, restarting
-services, or waiting for the device to reconnect. Removing the operation at
-that point would make the outcome harder to track and would introduce risky
-edge cases around partially completed upgrades.
+because the upgrade may be uploading or flashing a firmware image,
+restarting services, or waiting for the device to reconnect. Removing the
+operation at that point would make the outcome harder to track and would
+introduce risky edge cases around partially completed upgrades.
 
 If an upgrade is still in progress and the firmware image has not started
 flashing yet, cancel the operation instead. If cancellation is no longer
-available, wait until the operation completes and reaches one of the terminal
-states before deleting it.
+available, wait until the operation completes and reaches one of the
+terminal states before deleting it.
 
-The same rule applies to mass upgrades: a batch upgrade operation cannot be
-deleted while it is still ``in-progress``. Once the batch reaches a terminal
-state such as ``success``, ``failed``, or ``cancelled``, it can be deleted
-from the admin interface if the user has the required delete permission.
+The same rule applies to mass upgrades: a batch upgrade operation cannot
+be deleted while it is still ``in-progress``. Once the batch reaches a
+terminal state such as ``success``, ``failed``, or ``cancelled``, it can
+be deleted from the admin interface if the user has the required delete
+permission.

--- a/docs/user/upgrade-status.rst
+++ b/docs/user/upgrade-status.rst
@@ -183,3 +183,25 @@ about what occurred during the upgrade process.
 
 **Batch Operations**: When performing mass upgrades, you can monitor the
 status of individual device upgrades within the batch operation.
+
+Deleting Upgrade Operations
+---------------------------
+
+Upgrade operations and batch upgrade operations can be deleted from the
+admin interface only after they leave the ``in-progress`` state.
+
+Deleting an operation while it is still running is intentionally blocked
+because the upgrade may be uploading or flashing a firmware image, restarting
+services, or waiting for the device to reconnect. Removing the operation at
+that point would make the outcome harder to track and would introduce risky
+edge cases around partially completed upgrades.
+
+If an upgrade is still in progress and the firmware image has not started
+flashing yet, cancel the operation instead. If cancellation is no longer
+available, wait until the operation completes and reaches one of the terminal
+states before deleting it.
+
+The same rule applies to mass upgrades: a batch upgrade operation cannot be
+deleted while it is still ``in-progress``. Once the batch reaches a terminal
+state such as ``success``, ``failed``, or ``cancelled``, it can be deleted
+from the admin interface if the user has the required delete permission.

--- a/openwisp_firmware_upgrader/admin.py
+++ b/openwisp_firmware_upgrader/admin.py
@@ -55,9 +55,10 @@ Location = swapper.load_model("geo", "Location")
 DeviceGroup = swapper.load_model("config", "DeviceGroup")
 
 IN_PROGRESS_DELETE_MESSAGE = _(
-    "In-progress operations cannot be deleted. Cancel or complete them first."
+    "Some selected operations are still in progress and cannot be deleted. "
+    "Remove them from the selection and try again."
 )
-IN_PROGRESS_STATUS = UpgradeOperation._CANCELLABLE_STATUS
+IN_PROGRESS_STATUS = UpgradeOperation.CANCELLABLE_STATUS
 
 
 class BaseAdmin(MultitenantAdminMixin, TimeReadonlyAdminMixin, admin.ModelAdmin):
@@ -388,6 +389,7 @@ class BaseUpgradeAdmin(ReadonlyUpgradeOptionsMixin, ReadOnlyAdmin, BaseAdmin):
 
     @admin.action(description=delete_selected.short_description, permissions=["delete"])
     def delete_selected(self, request, queryset):
+        """Overrides default delete_selected action of from Django admin"""
         if queryset.filter(status=IN_PROGRESS_STATUS).exists():
             self.message_user(request, IN_PROGRESS_DELETE_MESSAGE, messages.ERROR)
             return None

--- a/openwisp_firmware_upgrader/admin.py
+++ b/openwisp_firmware_upgrader/admin.py
@@ -7,6 +7,7 @@ import swapper
 from django import forms
 from django.conf import settings
 from django.contrib import admin, messages
+from django.contrib.admin.actions import delete_selected
 from django.contrib.admin.helpers import ACTION_CHECKBOX_NAME
 from django.core.exceptions import ValidationError
 from django.core.paginator import InvalidPage, Paginator
@@ -51,6 +52,10 @@ DeviceConnection = swapper.load_model("connection", "DeviceConnection")
 Organization = swapper.load_model("openwisp_users", "Organization")
 Location = swapper.load_model("geo", "Location")
 DeviceGroup = swapper.load_model("config", "DeviceGroup")
+
+IN_PROGRESS_DELETE_MESSAGE = _(
+    "In-progress operations cannot be deleted. Cancel or complete them first."
+)
 
 
 class BaseAdmin(MultitenantAdminMixin, TimeReadonlyAdminMixin, admin.ModelAdmin):
@@ -324,7 +329,13 @@ class UpgradeOperationInline(admin.StackedInline):
     extra = 0
 
     def has_delete_permission(self, request, obj):
-        return False
+        # allow deleting except if in-progress, in which case operation must
+        # be cancelled first or wait until resolved (success/failed).
+        if not super().has_delete_permission(request, obj):
+            return False
+        if self.get_queryset(request).filter(status="in-progress").exists():
+            return False
+        return True
 
     def has_add_permission(self, request, obj):
         return False
@@ -362,8 +373,36 @@ class ReadonlyUpgradeOptionsMixin:
         )
 
 
+class BaseUpgradeAdmin(ReadonlyUpgradeOptionsMixin, ReadOnlyAdmin, BaseAdmin):
+    actions = ["delete_selected"]
+
+    def get_actions(self, request):
+        # skip ReadOnlyAdmin
+        return super(ReadOnlyAdmin, self).get_actions(request)
+
+    def delete_model(self, request, obj):
+        # skip ReadOnlyAdmin
+        super(ReadOnlyAdmin, self).delete_model(request, obj)
+
+    def has_delete_permission(self, request, obj=None):
+        # allow deleting except if in-progress, in which case operation must
+        # be cancelled first or wait until resolved (success/failed).
+        if not super(ReadOnlyAdmin, self).has_delete_permission(request, obj):
+            return False
+        if obj and obj.status == "in-progress":
+            return False
+        return True
+
+    @admin.action(description=delete_selected.short_description, permissions=["delete"])
+    def delete_selected(self, request, queryset):
+        if queryset.filter(status="in-progress").exists():
+            self.message_user(request, IN_PROGRESS_DELETE_MESSAGE, messages.ERROR)
+            return None
+        return delete_selected(self, request, queryset)
+
+
 @admin.register(UpgradeOperation)
-class UpgradeOperationAdmin(ReadonlyUpgradeOptionsMixin, ReadOnlyAdmin, BaseAdmin):
+class UpgradeOperationAdmin(BaseUpgradeAdmin):
     form = UpgradeOperationForm
     list_display = ["device", "status", "image", "modified"]
     list_filter = ["status"]
@@ -447,12 +486,9 @@ class UpgradeOperationAdmin(ReadonlyUpgradeOptionsMixin, ReadOnlyAdmin, BaseAdmi
     def has_add_permission(self, request):
         return False
 
-    def has_delete_permission(self, request, obj=None):
-        return False
-
 
 @admin.register(BatchUpgradeOperation)
-class BatchUpgradeOperationAdmin(ReadonlyUpgradeOptionsMixin, ReadOnlyAdmin, BaseAdmin):
+class BatchUpgradeOperationAdmin(BaseUpgradeAdmin):
     list_display = ["build", "organization", "status", "created", "modified"]
     list_filter = [
         BuildCategoryOrganizationFilter,

--- a/openwisp_firmware_upgrader/admin.py
+++ b/openwisp_firmware_upgrader/admin.py
@@ -56,6 +56,7 @@ DeviceGroup = swapper.load_model("config", "DeviceGroup")
 IN_PROGRESS_DELETE_MESSAGE = _(
     "In-progress operations cannot be deleted. Cancel or complete them first."
 )
+IN_PROGRESS_STATUS = UpgradeOperation._CANCELLABLE_STATUS
 
 
 class BaseAdmin(MultitenantAdminMixin, TimeReadonlyAdminMixin, admin.ModelAdmin):
@@ -333,7 +334,7 @@ class UpgradeOperationInline(admin.StackedInline):
         # be cancelled first or wait until resolved (success/failed).
         if not super().has_delete_permission(request, obj):
             return False
-        if self.get_queryset(request).filter(status="in-progress").exists():
+        if self.get_queryset(request).filter(status=IN_PROGRESS_STATUS).exists():
             return False
         return True
 
@@ -389,13 +390,13 @@ class BaseUpgradeAdmin(ReadonlyUpgradeOptionsMixin, ReadOnlyAdmin, BaseAdmin):
         # be cancelled first or wait until resolved (success/failed).
         if not super(ReadOnlyAdmin, self).has_delete_permission(request, obj):
             return False
-        if obj and obj.status == "in-progress":
+        if obj and obj.status == IN_PROGRESS_STATUS:
             return False
         return True
 
     @admin.action(description=delete_selected.short_description, permissions=["delete"])
     def delete_selected(self, request, queryset):
-        if queryset.filter(status="in-progress").exists():
+        if queryset.filter(status=IN_PROGRESS_STATUS).exists():
             self.message_user(request, IN_PROGRESS_DELETE_MESSAGE, messages.ERROR)
             return None
         return delete_selected(self, request, queryset)

--- a/openwisp_firmware_upgrader/admin.py
+++ b/openwisp_firmware_upgrader/admin.py
@@ -12,6 +12,7 @@ from django.contrib.admin.helpers import ACTION_CHECKBOX_NAME
 from django.core.exceptions import ValidationError
 from django.core.paginator import InvalidPage, Paginator
 from django.core.serializers.json import DjangoJSONEncoder
+from django.forms.formsets import DELETION_FIELD_NAME
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 from django.templatetags.static import static
@@ -328,15 +329,6 @@ class UpgradeOperationInline(admin.StackedInline):
     form = UpgradeOperationForm
     readonly_fields = UpgradeOperationForm.Meta.fields
     extra = 0
-
-    def has_delete_permission(self, request, obj):
-        # allow deleting except if in-progress, in which case operation must
-        # be cancelled first or wait until resolved (success/failed).
-        if not super().has_delete_permission(request, obj):
-            return False
-        if self.get_queryset(request).filter(status=IN_PROGRESS_STATUS).exists():
-            return False
-        return True
 
     def has_add_permission(self, request, obj):
         return False
@@ -765,6 +757,19 @@ class DeviceFormSet(forms.BaseInlineFormSet):
         return kwargs
 
 
+class DeviceUpgradeOperationFormSet(DeviceFormSet):
+    """Disable inline deletion of in-progress operations server-side."""
+
+    def add_fields(self, form, index):
+        super().add_fields(form, index)
+        if (
+            form.instance.pk
+            and form.instance.status == IN_PROGRESS_STATUS
+            and DELETION_FIELD_NAME in form.fields
+        ):
+            form.fields[DELETION_FIELD_NAME].disabled = True
+
+
 class DeviceFirmwareInline(
     MultitenantAdminMixin, DeactivatedDeviceReadOnlyMixin, admin.StackedInline
 ):
@@ -824,7 +829,7 @@ class DeviceUpgradeOperationForm(UpgradeOperationForm):
 class DeviceUpgradeOperationInline(ReadonlyUpgradeOptionsMixin, UpgradeOperationInline):
     verbose_name = _("Recent Firmware Upgrades")
     verbose_name_plural = verbose_name
-    formset = DeviceFormSet
+    formset = DeviceUpgradeOperationFormSet
     form = DeviceUpgradeOperationForm
     # hack for openwisp-monitoring integration
     # TODO: remove when this issue solved:

--- a/openwisp_firmware_upgrader/base/models.py
+++ b/openwisp_firmware_upgrader/base/models.py
@@ -811,7 +811,7 @@ class AbstractBatchUpgradeOperation(UpgradeOptionsMixin, TimeStampedEditableMode
 
 class AbstractUpgradeOperation(UpgradeOptionsMixin, TimeStampedEditableModel):
 
-    _CANCELLABLE_STATUS = "in-progress"
+    CANCELLABLE_STATUS = "in-progress"
     STATUS_CHOICES = (
         ("in-progress", _("in progress")),
         ("success", _("success")),
@@ -885,13 +885,13 @@ class AbstractUpgradeOperation(UpgradeOptionsMixin, TimeStampedEditableModel):
             # By using an UPDATE query, we avoid such situation.
             updated = self._meta.model.objects.filter(
                 pk=self.pk,
-                status=self._CANCELLABLE_STATUS,
+                status=self.CANCELLABLE_STATUS,
                 progress__lt=UpgradeProgress.CANCELLATION_THRESHOLD,
             ).update(status="cancelled")
             if not updated:
                 # The cancellation did not succeed, check why
                 self.refresh_from_db(fields=["status", "progress"])
-                if self.status != self._CANCELLABLE_STATUS:
+                if self.status != self.CANCELLABLE_STATUS:
                     raise ValueError(
                         _("Cannot cancel operation with status: %(status)s")
                         % {"status": self.status}

--- a/openwisp_firmware_upgrader/static/firmware-upgrader/css/batch-upgrade-operation.css
+++ b/openwisp_firmware_upgrader/static/firmware-upgrader/css/batch-upgrade-operation.css
@@ -1,6 +1,14 @@
 #batchupgradeoperation_form .submit-row {
   display: none;
 }
+#batchupgradeoperation_form .submit-row:first-child,
+#batchupgradeoperation_form .submit-row:first-child .deletelink-box {
+  display: block;
+}
+/* hide empty submit rows */
+#batchupgradeoperation_form .submit-row:not(:has(*)) {
+  display: none !important;
+}
 
 .upgrade-operations-title {
   font-size: 22px;

--- a/openwisp_firmware_upgrader/static/firmware-upgrader/css/device-firmware.css
+++ b/openwisp_firmware_upgrader/static/firmware-upgrader/css/device-firmware.css
@@ -17,3 +17,6 @@
 #devicefirmware-group .form-row.field-upgrade_options {
   display: none;
 }
+.dynamic-upgradeoperation_set .delete:has(input[type="checkbox"][disabled]) {
+  display: none;
+}

--- a/openwisp_firmware_upgrader/static/firmware-upgrader/css/upgrade-options.css
+++ b/openwisp_firmware_upgrader/static/firmware-upgrader/css/upgrade-options.css
@@ -8,6 +8,8 @@
 .readonly-upgrade-options li img {
   margin-right: 5px;
 }
-#upgradeoperation_form .submit-row {
+#upgradeoperation_form .submit-row:first-child,
+/* hide empty submit rows */
+#upgradeoperation_form .submit-row:not(:has(*)) {
   display: none;
 }

--- a/openwisp_firmware_upgrader/tests/test_admin.py
+++ b/openwisp_firmware_upgrader/tests/test_admin.py
@@ -1,4 +1,5 @@
 import json
+import re
 from datetime import timedelta
 from unittest import mock
 
@@ -7,7 +8,7 @@ import swapper
 from django.contrib.admin.helpers import ACTION_CHECKBOX_NAME
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
-from django.test import RequestFactory, TestCase, TransactionTestCase
+from django.test import RequestFactory, TestCase, TransactionTestCase, override_settings
 from django.urls import reverse
 from django.utils.timezone import localtime
 
@@ -120,6 +121,7 @@ class BaseTestAdmin(TestMultitenantAdminMixin, TestUpgraderMixin):
         return reverse(f"admin:{self.app_label}_build_changelist")
 
 
+@override_settings(LANGUAGE_CODE="en")
 class TestAdmin(BaseTestAdmin, TestCase):
     def test_build_list(self):
         self._login()
@@ -555,6 +557,18 @@ class TestAdmin(BaseTestAdmin, TestCase):
             '<select name="devicefirmware-0-image" id="id_devicefirmware-0-image">',
         )
 
+    def test_deactivated_device_upgrade_operation_readonly(self):
+        self._login()
+        device = self._create_config(organization=self._get_org()).device
+        device.deactivate()
+        operation = UpgradeOperation.objects.create(device=device, status="failed")
+        response = self.client.get(
+            reverse(f"admin:{self.config_app_label}_device_change", args=[device.id])
+        )
+        self.assertContains(response, str(operation.pk))
+        # deactivated devices are readonly
+        self.assertNotContains(response, 'name="upgradeoperation_set-0-DELETE"')
+
     def test_device_upgrade_shared_firmware(self, *args):
         org = self._get_org()
         administrator = self._create_administrator(organizations=[org])
@@ -801,10 +815,10 @@ class TestAdmin(BaseTestAdmin, TestCase):
         return params
 
     def _get_input_tag(self, content, name):
-        name_index = content.index(f'name="{name}"')
-        input_start = content.rfind("<input", 0, name_index)
-        input_end = content.index(">", name_index) + 1
-        return content[input_start:input_end]
+        match = re.search(rf'<input\b[^>]*\bname="{re.escape(name)}"[^>]*>', content)
+        if not match:
+            raise ValueError(f'Input with name="{name}" not found')
+        return match.group(0)
 
     def test_device_bulk_delete_with_upgrade_operation(self):
         self._login()
@@ -897,7 +911,8 @@ class TestAdmin(BaseTestAdmin, TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(
             response,
-            "In-progress operations cannot be deleted. Cancel or complete them first.",
+            "Some selected operations are still in progress and cannot be deleted. "
+            "Remove them from the selection and try again.",
         )
         self.assertTrue(UpgradeOperation.objects.filter(pk=operation.pk).exists())
         self.assertTrue(
@@ -962,7 +977,8 @@ class TestAdmin(BaseTestAdmin, TestCase):
             self.assertEqual(response.status_code, 200)
             self.assertContains(
                 response,
-                "In-progress operations cannot be deleted. Cancel or complete them first.",
+                "Some selected operations are still in progress and cannot be deleted. "
+                "Remove them from the selection and try again.",
             )
             self.assertTrue(BatchUpgradeOperation.objects.filter(pk=batch.pk).exists())
             self.assertTrue(

--- a/openwisp_firmware_upgrader/tests/test_admin.py
+++ b/openwisp_firmware_upgrader/tests/test_admin.py
@@ -782,6 +782,191 @@ class TestAdmin(BaseTestAdmin, TestCase):
                 html=True,
             )
 
+    def _get_device_upgrade_operation_delete_params(
+        self, device, device_conn, device_fw, operation
+    ):
+        params = self._get_device_params(
+            device, device_conn, device_fw.image, device_fw
+        )
+        params.update(
+            {
+                "upgradeoperation_set-TOTAL_FORMS": 1,
+                "upgradeoperation_set-INITIAL_FORMS": 1,
+                "upgradeoperation_set-MIN_NUM_FORMS": 0,
+                "upgradeoperation_set-MAX_NUM_FORMS": 0,
+                "upgradeoperation_set-0-id": str(operation.pk),
+                "upgradeoperation_set-0-DELETE": "on",
+            }
+        )
+        return params
+
+    def test_device_bulk_delete_with_upgrade_operation(self):
+        self._login()
+        org = self._create_org(name="bulk-delete-org", slug="bulk-delete-org")
+        device = self._create_device_with_connection(organization=org)
+        device.deactivate()
+        device.config.set_status_deactivated()
+        operation = UpgradeOperation.objects.create(device=device)
+        changelist_url = reverse(f"admin:{self.config_app_label}_device_changelist")
+        payload = {
+            "action": "delete_selected",
+            ACTION_CHECKBOX_NAME: [str(device.pk)],
+        }
+
+        with self.subTest("in-progress operation blocks device bulk delete"):
+            response = self.client.post(changelist_url, data=payload)
+            self.assertEqual(response.status_code, 200)
+            self.assertContains(response, "Cannot delete Device")
+            self.assertContains(response, "upgrade operation")
+            self.assertIn("upgrade operation", response.context["perms_lacking"])
+            self.assertTrue(Device.objects.filter(pk=device.pk).exists())
+            self.assertTrue(UpgradeOperation.objects.filter(pk=operation.pk).exists())
+
+        with self.subTest("failed operation allows device bulk delete"):
+            operation.status = "failed"
+            operation.save(update_fields=["status"])
+            response = self.client.post(changelist_url, data=payload)
+            self.assertEqual(response.status_code, 200)
+            self.assertNotContains(response, "Cannot delete")
+            self.assertNotContains(response, "upgrade operation")
+            self.assertEqual(response.context["perms_lacking"], set())
+            payload["post"] = "yes"
+            response = self.client.post(changelist_url, data=payload, follow=True)
+            self.assertEqual(response.status_code, 200)
+            self.assertFalse(Device.objects.filter(pk=device.pk).exists())
+            self.assertFalse(UpgradeOperation.objects.filter(pk=operation.pk).exists())
+
+    def test_upgrade_operation_admin_delete_selected_action_present(self):
+        self._login()
+        device = self._create_device_with_connection()
+        UpgradeOperation.objects.create(device=device, status="failed")
+        url = reverse(f"admin:{self.app_label}_upgradeoperation_changelist")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '<option value="delete_selected">')
+
+    def test_upgrade_operation_admin_bulk_delete_in_progress_not_allowed(self):
+        self._login()
+        device = self._create_device_with_connection()
+        operation = UpgradeOperation.objects.create(device=device)
+        failed_operation = UpgradeOperation.objects.create(
+            device=device, status="failed"
+        )
+        url = reverse(f"admin:{self.app_label}_upgradeoperation_changelist")
+        response = self.client.post(
+            url,
+            data={
+                "action": "delete_selected",
+                ACTION_CHECKBOX_NAME: [str(operation.pk), str(failed_operation.pk)],
+                "post": "yes",
+            },
+            follow=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            "In-progress operations cannot be deleted. Cancel or complete them first.",
+        )
+        self.assertTrue(UpgradeOperation.objects.filter(pk=operation.pk).exists())
+        self.assertTrue(
+            UpgradeOperation.objects.filter(pk=failed_operation.pk).exists()
+        )
+
+    def test_batch_upgrade_operation_admin_delete_selected_action_present(self):
+        self._login()
+        build = self._create_build()
+        BatchUpgradeOperation.objects.create(build=build, status="failed")
+        url = reverse(f"admin:{self.app_label}_batchupgradeoperation_changelist")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '<option value="delete_selected">')
+
+    def test_batch_upgrade_operation_admin_bulk_delete_by_status(self):
+        self._login()
+        org = self._get_org()
+        build = self._create_build(category=self._create_category(organization=org))
+        batch = BatchUpgradeOperation.objects.create(build=build, status="in-progress")
+        device = self._create_device_with_connection(organization=org)
+        operation = UpgradeOperation.objects.create(device=device, batch=batch)
+        url = reverse(f"admin:{self.app_label}_batchupgradeoperation_changelist")
+        payload = {
+            "action": "delete_selected",
+            ACTION_CHECKBOX_NAME: [str(batch.pk)],
+        }
+
+        with self.subTest("in-progress batch cannot be deleted"):
+            failed_batch = BatchUpgradeOperation.objects.create(
+                build=build, status="failed"
+            )
+            payload[ACTION_CHECKBOX_NAME].append(str(failed_batch.pk))
+            payload["post"] = "yes"
+            response = self.client.post(url, data=payload, follow=True)
+            self.assertEqual(response.status_code, 200)
+            self.assertContains(
+                response,
+                "In-progress operations cannot be deleted. Cancel or complete them first.",
+            )
+            self.assertTrue(BatchUpgradeOperation.objects.filter(pk=batch.pk).exists())
+            self.assertTrue(
+                BatchUpgradeOperation.objects.filter(pk=failed_batch.pk).exists()
+            )
+            self.assertTrue(UpgradeOperation.objects.filter(pk=operation.pk).exists())
+            payload[ACTION_CHECKBOX_NAME].remove(str(failed_batch.pk))
+            payload.pop("post")
+            failed_batch.delete()
+
+        with self.subTest("failed batch can be deleted"):
+            operation.status = "failed"
+            operation.save(update_fields=["status"])
+            batch.refresh_from_db()
+            self.assertEqual(batch.status, "failed")
+            response = self.client.post(url, data=payload)
+            self.assertEqual(response.status_code, 200)
+            self.assertNotContains(response, "Cannot delete")
+            payload["post"] = "yes"
+            response = self.client.post(url, data=payload, follow=True)
+            self.assertEqual(response.status_code, 200)
+            self.assertFalse(BatchUpgradeOperation.objects.filter(pk=batch.pk).exists())
+            self.assertFalse(UpgradeOperation.objects.filter(pk=operation.pk).exists())
+
+    def test_device_upgrade_operation_inline_delete_by_status(self):
+        self._login()
+        device = self._create_device_with_connection()
+        device_conn = device.deviceconnection_set.first()
+        device_fw = self._create_device_firmware(device=device, device_connection=False)
+        operation = UpgradeOperation.objects.create(device=device)
+        url = reverse(f"admin:{self.config_app_label}_device_change", args=[device.pk])
+
+        with self.subTest("in-progress operation cannot be deleted inline"):
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 200)
+            self.assertNotContains(response, 'name="upgradeoperation_set-0-DELETE"')
+            response = self.client.post(
+                url,
+                data=self._get_device_upgrade_operation_delete_params(
+                    device, device_conn, device_fw, operation
+                ),
+                follow=True,
+            )
+            self.assertEqual(response.status_code, 200)
+            self.assertTrue(UpgradeOperation.objects.filter(pk=operation.pk).exists())
+
+        with self.subTest("failed operation can be deleted inline"):
+            operation.status = "failed"
+            operation.save(update_fields=["status"])
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 200)
+            self.assertContains(response, 'name="upgradeoperation_set-0-DELETE"')
+            response = self.client.post(
+                url,
+                data=self._get_device_upgrade_operation_delete_params(
+                    device, device_conn, device_fw, operation
+                ),
+                follow=True,
+            )
+            self.assertEqual(response.status_code, 200)
+            self.assertFalse(UpgradeOperation.objects.filter(pk=operation.pk).exists())
+
 
 class TestAdminTransaction(
     BaseTestAdmin, AdminActionPermTestMixin, TransactionTestCase

--- a/openwisp_firmware_upgrader/tests/test_admin.py
+++ b/openwisp_firmware_upgrader/tests/test_admin.py
@@ -851,6 +851,32 @@ class TestAdmin(BaseTestAdmin, TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, '<option value="delete_selected">')
 
+    def test_upgrade_operation_admin_delete_by_status(self):
+        self._login()
+        device = self._create_device_with_connection()
+        operation = UpgradeOperation.objects.create(device=device)
+        change_url = reverse(
+            f"admin:{self.app_label}_upgradeoperation_change", args=[operation.pk]
+        )
+        delete_url = reverse(
+            f"admin:{self.app_label}_upgradeoperation_delete", args=[operation.pk]
+        )
+
+        with self.subTest("in-progress operation does not show delete button"):
+            response = self.client.get(change_url)
+            self.assertEqual(response.status_code, 200)
+            self.assertNotContains(response, delete_url)
+
+        with self.subTest("failed operation can be deleted"):
+            operation.status = "failed"
+            operation.save(update_fields=["status"])
+            response = self.client.get(change_url)
+            self.assertEqual(response.status_code, 200)
+            self.assertContains(response, delete_url)
+            response = self.client.post(delete_url, {"post": "yes"}, follow=True)
+            self.assertEqual(response.status_code, 200)
+            self.assertFalse(UpgradeOperation.objects.filter(pk=operation.pk).exists())
+
     def test_upgrade_operation_admin_bulk_delete_in_progress_not_allowed(self):
         self._login()
         device = self._create_device_with_connection()
@@ -886,6 +912,32 @@ class TestAdmin(BaseTestAdmin, TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, '<option value="delete_selected">')
+
+    def test_batch_upgrade_operation_admin_delete_by_status(self):
+        self._login()
+        build = self._create_build()
+        batch = BatchUpgradeOperation.objects.create(build=build, status="in-progress")
+        change_url = reverse(
+            f"admin:{self.app_label}_batchupgradeoperation_change", args=[batch.pk]
+        )
+        delete_url = reverse(
+            f"admin:{self.app_label}_batchupgradeoperation_delete", args=[batch.pk]
+        )
+
+        with self.subTest("in-progress batch does not show delete button"):
+            response = self.client.get(change_url)
+            self.assertEqual(response.status_code, 200)
+            self.assertNotContains(response, delete_url)
+
+        with self.subTest("failed batch can be deleted"):
+            batch.status = "failed"
+            batch.save(update_fields=["status"])
+            response = self.client.get(change_url)
+            self.assertEqual(response.status_code, 200)
+            self.assertContains(response, delete_url)
+            response = self.client.post(delete_url, {"post": "yes"}, follow=True)
+            self.assertEqual(response.status_code, 200)
+            self.assertFalse(BatchUpgradeOperation.objects.filter(pk=batch.pk).exists())
 
     def test_batch_upgrade_operation_admin_bulk_delete_by_status(self):
         self._login()

--- a/openwisp_firmware_upgrader/tests/test_admin.py
+++ b/openwisp_firmware_upgrader/tests/test_admin.py
@@ -800,6 +800,12 @@ class TestAdmin(BaseTestAdmin, TestCase):
         )
         return params
 
+    def _get_input_tag(self, content, name):
+        name_index = content.index(f'name="{name}"')
+        input_start = content.rfind("<input", 0, name_index)
+        input_end = content.index(">", name_index) + 1
+        return content[input_start:input_end]
+
     def test_device_bulk_delete_with_upgrade_operation(self):
         self._login()
         org = self._create_org(name="bulk-delete-org", slug="bulk-delete-org")
@@ -940,7 +946,10 @@ class TestAdmin(BaseTestAdmin, TestCase):
         with self.subTest("in-progress operation cannot be deleted inline"):
             response = self.client.get(url)
             self.assertEqual(response.status_code, 200)
-            self.assertNotContains(response, 'name="upgradeoperation_set-0-DELETE"')
+            delete_input = self._get_input_tag(
+                response.content.decode(), "upgradeoperation_set-0-DELETE"
+            )
+            self.assertIn("disabled", delete_input)
             response = self.client.post(
                 url,
                 data=self._get_device_upgrade_operation_delete_params(
@@ -966,6 +975,32 @@ class TestAdmin(BaseTestAdmin, TestCase):
             )
             self.assertEqual(response.status_code, 200)
             self.assertFalse(UpgradeOperation.objects.filter(pk=operation.pk).exists())
+
+    def test_device_upgrade_operation_inline_delete_mixed_statuses(self):
+        self._login()
+        device = self._create_device_with_connection()
+        self._create_device_firmware(device=device, device_connection=False)
+        in_progress_operation = UpgradeOperation.objects.create(device=device)
+        failed_operation = UpgradeOperation.objects.create(
+            device=device, status="failed"
+        )
+        url = reverse(f"admin:{self.config_app_label}_device_change", args=[device.pk])
+        response = self.client.get(url)
+        content = response.content.decode()
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(f'value="{failed_operation.pk}"', content)
+        self.assertIn(f'value="{in_progress_operation.pk}"', content)
+        failed_index = content.index(f'value="{failed_operation.pk}"')
+        in_progress_index = content.index(f'value="{in_progress_operation.pk}"')
+        failed_delete_input = self._get_input_tag(
+            content, "upgradeoperation_set-0-DELETE"
+        )
+        in_progress_delete_input = self._get_input_tag(
+            content, "upgradeoperation_set-1-DELETE"
+        )
+        self.assertNotIn("disabled", failed_delete_input)
+        self.assertIn("disabled", in_progress_delete_input)
+        self.assertLess(failed_index, in_progress_index)
 
 
 class TestAdminTransaction(


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #145.

## Description of Changes

Allows completed single and batch upgrade operations to be deleted from the admin while keeping deletion blocked for in-progress operations.

## Screenshots

<img width="998" height="736" alt="image" src="https://github.com/user-attachments/assets/a66f67da-cd8f-434e-b1c3-0e2048145e19" />

<img width="995" height="543" alt="image" src="https://github.com/user-attachments/assets/275c96db-78e2-4c1d-a238-480a9c16a3b5" />

