### PR TITLE
[tests] Changed mock decorators to contextmanagers for extensibility

### DIFF
--- a/openwisp_firmware_upgrader/tests/test_selenium.py
+++ b/openwisp_firmware_upgrader/tests/test_selenium.py
@@ -43,6 +43,8 @@ class TestDeviceAdmin(TestUpgraderMixin, SeleniumTestMixin, StaticLiveServerTest
     firmware_app_label = Build._meta.app_label
     os = "OpenWrt 19.07-SNAPSHOT r11061-6ffd4d8a4d"
     image_type = REVERSE_FIRMWARE_IMAGE_MAP["YunCore XD3200"]
+    _mock_upgrade = "openwisp_firmware_upgrader.upgraders.openwrt.OpenWrt.upgrade"
+    _mock_connect = "openwisp_controller.connection.models.DeviceConnection.connect"
 
     def _set_up_env(self):
         org = self._get_org()
@@ -125,14 +127,7 @@ class TestDeviceAdmin(TestUpgraderMixin, SeleniumTestMixin, StaticLiveServerTest
         self.assertEqual(DeviceConnection.objects.count(), 1)
         self.assertEqual(DeviceFirmware.objects.count(), 1)
 
-    @patch(
-        "openwisp_firmware_upgrader.upgraders.openwrt.OpenWrt.upgrade",
-        return_value=True,
-    )
-    @patch(
-        "openwisp_controller.connection.models.DeviceConnection.connect",
-        return_value=True,
-    )
+    @patch(_mock_upgrade, return_value=True)
     def test_device_firmware_upgrade_options(self, *args):
         def save_device():
             self.find_element(
@@ -141,158 +136,9 @@ class TestDeviceAdmin(TestUpgraderMixin, SeleniumTestMixin, StaticLiveServerTest
             self.wait_for_visibility(By.CSS_SELECTOR, "#devicefirmware-group")
             self.hide_loading_overlay()
 
-        _, _, _, _, _, image, device = self._set_up_env()
-        self.login()
-        self.open(
-            "{}#devicefirmware-group".format(
-                reverse(
-                    f"admin:{self.config_app_label}_device_change", args=[device.id]
-                )
-            )
-        )
-        self.hide_loading_overlay()
-        # JSONSchema Editor should not be rendered without a change in the image field
-        self.wait_for_invisibility(
-            By.CSS_SELECTOR, "#devicefirmware-group .jsoneditor-wrapper"
-        )
-        image_select = self._get_device_firmware_dropdown_select()
-        image_select.select_by_value(str(image.pk))
-        # JSONSchema configuration editor should not be rendered
-        self.wait_for_invisibility(
-            By.XPATH,
-            '//*[@id="id_devicefirmware-0-upgrade_options_jsoneditor"]/div/h3/span[4]/input',
-        )
-        # Select "None" image should hide JSONSchema Editor
-        image_select.select_by_value("")
-        self.wait_for_invisibility(
-            By.CSS_SELECTOR, "#id_devicefirmware-0-upgrade_options_jsoneditor"
-        )
-
-        # Select "build2" image
-        image_select.select_by_value(str(image.pk))
-        # Enable '-c' option
-        self.find_element(
-            by=By.XPATH,
-            value='//*[@id="id_devicefirmware-0-upgrade_options_jsoneditor"]'
-            "/div/div[2]/div/div/div[1]/div/div[1]/label/input",
-        ).click()
-        # Enable '-F' option
-        self.find_element(
-            by=By.XPATH,
-            value='//*[@id="id_devicefirmware-0-upgrade_options_jsoneditor"]'
-            "/div/div[2]/div/div/div[7]/div/div[1]/label/input",
-        ).click()
-        save_device()
-
-        # Delete DeviceFirmware
-        self.find_element(By.CSS_SELECTOR, "#id_devicefirmware-0-DELETE").click()
-        save_device()
-
-        # When adding firmware to the device for the first time,
-        # JSONSchema editor should be rendered only when the image
-        # is selected
-        self.find_element(
-            by=By.XPATH, value='//*[@id="devicefirmware-group"]/fieldset/div[2]/a'
-        ).click()
-        # JSONSchema Editor should not be rendered without a change in the image field
-        self.wait_for_invisibility(
-            By.CSS_SELECTOR, "#devicefirmware-group .jsoneditor-wrapper"
-        )
-        image_select = self._get_device_firmware_dropdown_select()
-        image_select.select_by_index(1)
-        self.wait_for_visibility(
-            By.CSS_SELECTOR, "#devicefirmware-group .jsoneditor-wrapper"
-        )
-        save_device()
-
-    @patch(
-        "openwisp_firmware_upgrader.upgraders.openwrt.OpenWrt.upgrade",
-        return_value=True,
-    )
-    @patch(
-        "openwisp_controller.connection.models.DeviceConnection.connect",
-        return_value=True,
-    )
-    def test_batch_upgrade_upgrade_options(self, *args):
-        _, _, _, build2, _, _, _ = self._set_up_env()
-        self.login()
-        self.open(
-            reverse(f"admin:{self.firmware_app_label}_build_change", args=[build2.id])
-        )
-        # Launch mass upgrade operation
-        self.find_element(
-            by=By.CSS_SELECTOR,
-            value='.title-wrapper .object-tools form button[type="submit"]',
-        ).click()
-
-        # Ensure JSONSchema form is rendered
-        self.wait_for_visibility(By.CSS_SELECTOR, ".jsoneditor-wrapper")
-        # JSONSchema configuration editor should not be rendered
-        self.wait_for_invisibility(
-            By.XPATH,
-            '//*[@id="id_devicefirmware-0-upgrade_options_jsoneditor"]/div/h3/span[4]/input',
-        )
-        # Disable -c flag
-        self.find_element(
-            by=By.XPATH,
-            value='//*[@id="id_upgrade_options_jsoneditor"]/div/div[2]/div/div/div[1]/div/div[1]/label/input',
-        ).click()
-        # Enable -n flag
-        self.find_element(
-            by=By.XPATH,
-            value='//*[@id="id_upgrade_options_jsoneditor"]/div/div[2]/div/div/div[3]/div/div[1]/label/input',
-        ).click()
-        # Upgrade all devices
-        self.find_element(by=By.CSS_SELECTOR, value='input[name="upgrade_all"]').click()
-        try:
-            WebDriverWait(self.web_driver, 5).until(
-                EC.url_contains("batchupgradeoperation")
-            )
-        except TimeoutException:
-            self.fail("User was not redirected to Mass upgrade operations page")
-        self.assertEqual(
-            BatchUpgradeOperation.objects.filter(
-                upgrade_options={
-                    "c": False,
-                    "o": False,
-                    "n": True,
-                    "u": False,
-                    "p": False,
-                    "k": False,
-                    "F": False,
-                }
-            ).count(),
-            1,
-        )
-        self.assertEqual(
-            UpgradeOperation.objects.filter(
-                upgrade_options={
-                    "c": False,
-                    "o": False,
-                    "n": True,
-                    "u": False,
-                    "p": False,
-                    "k": False,
-                    "F": False,
-                }
-            ).count(),
-            1,
-        )
-
-    @patch(
-        "openwisp_firmware_upgrader.upgraders.openwrt.OpenWrt.upgrade",
-        return_value=True,
-    )
-    @patch(
-        "openwisp_controller.connection.models.DeviceConnection.connect",
-        return_value=True,
-    )
-    @patch.object(OpenWrt, "SCHEMA", None)
-    def test_upgrader_with_unsupported_upgrade_options(self, *args):
-        _org, _category, _build1, build2, _image1, image2, device = self._set_up_env()
-        self.login()
-
-        with self.subTest("Test DeviceFirmware"):
+        with patch(self._mock_connect, return_value=True):
+            _, _, _, _, _, image, device = self._set_up_env()
+            self.login()
             self.open(
                 "{}#devicefirmware-group".format(
                     reverse(
@@ -301,24 +147,65 @@ class TestDeviceAdmin(TestUpgraderMixin, SeleniumTestMixin, StaticLiveServerTest
                 )
             )
             self.hide_loading_overlay()
-            image_select = self._get_device_firmware_dropdown_select()
-            image_select.select_by_value(str(image2.pk))
-            # Ensure JSONSchema editor is not rendered because
-            # the upgrader does not define a schema
+            # JSONSchema Editor should not be rendered without a change in the image field
             self.wait_for_invisibility(
                 By.CSS_SELECTOR, "#devicefirmware-group .jsoneditor-wrapper"
             )
-            self.find_element(
-                by=By.XPATH, value='//*[@id="device_form"]/div/div[1]/input[3]'
-            ).click()
-            self.wait_for_visibility(By.CSS_SELECTOR, "#devicefirmware-group")
-            self.assertEqual(
-                UpgradeOperation.objects.filter(upgrade_options={}).count(), 1
+            image_select = self._get_device_firmware_dropdown_select()
+            image_select.select_by_value(str(image.pk))
+            # JSONSchema configuration editor should not be rendered
+            self.wait_for_invisibility(
+                By.XPATH,
+                '//*[@id="id_devicefirmware-0-upgrade_options_jsoneditor"]/div/h3/span[4]/input',
             )
-        DeviceFirmware.objects.all().delete()
-        UpgradeOperation.objects.all().delete()
+            # Select "None" image should hide JSONSchema Editor
+            image_select.select_by_value("")
+            self.wait_for_invisibility(
+                By.CSS_SELECTOR, "#id_devicefirmware-0-upgrade_options_jsoneditor"
+            )
 
-        with self.subTest("Test BatchUpgradeOperation"):
+            # Select "build2" image
+            image_select.select_by_value(str(image.pk))
+            # Enable '-c' option
+            self.find_element(
+                by=By.XPATH,
+                value='//*[@id="id_devicefirmware-0-upgrade_options_jsoneditor"]'
+                "/div/div[2]/div/div/div[1]/div/div[1]/label/input",
+            ).click()
+            # Enable '-F' option
+            self.find_element(
+                by=By.XPATH,
+                value='//*[@id="id_devicefirmware-0-upgrade_options_jsoneditor"]'
+                "/div/div[2]/div/div/div[7]/div/div[1]/label/input",
+            ).click()
+            save_device()
+
+            # Delete DeviceFirmware
+            self.find_element(By.CSS_SELECTOR, "#id_devicefirmware-0-DELETE").click()
+            save_device()
+
+            # When adding firmware to the device for the first time,
+            # JSONSchema editor should be rendered only when the image
+            # is selected
+            self.find_element(
+                by=By.XPATH, value='//*[@id="devicefirmware-group"]/fieldset/div[2]/a'
+            ).click()
+            # JSONSchema Editor should not be rendered without a change in the image field
+            self.wait_for_invisibility(
+                By.CSS_SELECTOR, "#devicefirmware-group .jsoneditor-wrapper"
+            )
+            image_select = self._get_device_firmware_dropdown_select()
+            image_select.select_by_index(1)
+            self.wait_for_visibility(
+                By.CSS_SELECTOR, "#devicefirmware-group .jsoneditor-wrapper"
+            )
+            save_device()
+
+    @patch(_mock_upgrade, return_value=True)
+    def test_batch_upgrade_upgrade_options(self, *args):
+        with patch(self._mock_connect, return_value=True):
+            _, _, _, build2, _, _, _ = self._set_up_env()
+            self.login()
             self.open(
                 reverse(
                     f"admin:{self.firmware_app_label}_build_change", args=[build2.id]
@@ -329,23 +216,130 @@ class TestDeviceAdmin(TestUpgraderMixin, SeleniumTestMixin, StaticLiveServerTest
                 by=By.CSS_SELECTOR,
                 value='.title-wrapper .object-tools form button[type="submit"]',
             ).click()
-            # Ensure JSONSchema editor is not rendered because
-            # the upgrader does not define a schema
+
+            # Ensure JSONSchema form is rendered
+            self.wait_for_visibility(By.CSS_SELECTOR, ".jsoneditor-wrapper")
+            # JSONSchema configuration editor should not be rendered
             self.wait_for_invisibility(
-                By.CSS_SELECTOR, "#devicefirmware-group .jsoneditor-wrapper"
+                By.XPATH,
+                '//*[@id="id_devicefirmware-0-upgrade_options_jsoneditor"]/div/h3/span[4]/input',
             )
+            # Disable -c flag
+            self.find_element(
+                by=By.XPATH,
+                value='//*[@id="id_upgrade_options_jsoneditor"]'
+                "/div/div[2]/div/div/div[1]/div/div[1]/label/input",
+            ).click()
+            # Enable -n flag
+            self.find_element(
+                by=By.XPATH,
+                value='//*[@id="id_upgrade_options_jsoneditor"]'
+                "/div/div[2]/div/div/div[3]/div/div[1]/label/input",
+            ).click()
             # Upgrade all devices
             self.find_element(
                 by=By.CSS_SELECTOR, value='input[name="upgrade_all"]'
             ).click()
-            self.wait_for_presence(By.ID, "batchupgradeoperation_form")
-            self.wait_for_presence(By.CSS_SELECTOR, ".messagelist .success")
+            try:
+                WebDriverWait(self.web_driver, 5).until(
+                    EC.url_contains("batchupgradeoperation")
+                )
+            except TimeoutException:
+                self.fail("User was not redirected to Mass upgrade operations page")
             self.assertEqual(
-                UpgradeOperation.objects.filter(upgrade_options={}).count(), 1
+                BatchUpgradeOperation.objects.filter(
+                    upgrade_options={
+                        "c": False,
+                        "o": False,
+                        "n": True,
+                        "u": False,
+                        "p": False,
+                        "k": False,
+                        "F": False,
+                    }
+                ).count(),
+                1,
             )
             self.assertEqual(
-                BatchUpgradeOperation.objects.filter(upgrade_options={}).count(), 1
+                UpgradeOperation.objects.filter(
+                    upgrade_options={
+                        "c": False,
+                        "o": False,
+                        "n": True,
+                        "u": False,
+                        "p": False,
+                        "k": False,
+                        "F": False,
+                    }
+                ).count(),
+                1,
             )
+
+    @patch(_mock_upgrade, return_value=True)
+    @patch.object(OpenWrt, "SCHEMA", None)
+    def test_upgrader_with_unsupported_upgrade_options(self, *args):
+        with patch(self._mock_connect, return_value=True):
+            _org, _category, _build1, build2, _image1, image2, device = (
+                self._set_up_env()
+            )
+            self.login()
+
+            with self.subTest("Test DeviceFirmware"):
+                self.open(
+                    "{}#devicefirmware-group".format(
+                        reverse(
+                            f"admin:{self.config_app_label}_device_change",
+                            args=[device.id],
+                        )
+                    )
+                )
+                self.hide_loading_overlay()
+                image_select = self._get_device_firmware_dropdown_select()
+                image_select.select_by_value(str(image2.pk))
+                # Ensure JSONSchema editor is not rendered because
+                # the upgrader does not define a schema
+                self.wait_for_invisibility(
+                    By.CSS_SELECTOR, "#devicefirmware-group .jsoneditor-wrapper"
+                )
+                self.find_element(
+                    by=By.XPATH, value='//*[@id="device_form"]/div/div[1]/input[3]'
+                ).click()
+                self.wait_for_visibility(By.CSS_SELECTOR, "#devicefirmware-group")
+                self.assertEqual(
+                    UpgradeOperation.objects.filter(upgrade_options={}).count(), 1
+                )
+            DeviceFirmware.objects.all().delete()
+            UpgradeOperation.objects.all().delete()
+
+            with self.subTest("Test BatchUpgradeOperation"):
+                self.open(
+                    reverse(
+                        f"admin:{self.firmware_app_label}_build_change",
+                        args=[build2.id],
+                    )
+                )
+                # Launch mass upgrade operation
+                self.find_element(
+                    by=By.CSS_SELECTOR,
+                    value='.title-wrapper .object-tools form button[type="submit"]',
+                ).click()
+                # Ensure JSONSchema editor is not rendered because
+                # the upgrader does not define a schema
+                self.wait_for_invisibility(
+                    By.CSS_SELECTOR, "#devicefirmware-group .jsoneditor-wrapper"
+                )
+                # Upgrade all devices
+                self.find_element(
+                    by=By.CSS_SELECTOR, value='input[name="upgrade_all"]'
+                ).click()
+                self.wait_for_presence(By.ID, "batchupgradeoperation_form")
+                self.wait_for_presence(By.CSS_SELECTOR, ".messagelist .success")
+                self.assertEqual(
+                    UpgradeOperation.objects.filter(upgrade_options={}).count(), 1
+                )
+                self.assertEqual(
+                    BatchUpgradeOperation.objects.filter(upgrade_options={}).count(), 1
+                )
 
     def test_upgrade_cancel_modal(self):
         """Test upgrade cancel modal functionality"""
@@ -456,26 +450,21 @@ class TestDeviceAdmin(TestUpgraderMixin, SeleniumTestMixin, StaticLiveServerTest
             "Both group and location Select2 widgets are initialized",
         )
 
-    @patch(
-        "openwisp_firmware_upgrader.upgraders.openwrt.OpenWrt.upgrade",
-        return_value=True,
-    )
-    @patch(
-        "openwisp_controller.connection.models.DeviceConnection.connect",
-        return_value=True,
-    )
+    @patch(_mock_upgrade, return_value=True)
     def test_upgrade_operation_admin_no_submit_row(self, *args):
         """Test that UpgradeOperation admin change page does not display submit-row"""
-        # Create device firmware and upgrade
-        self._create_device_firmware(upgrade=True)
-        uo = UpgradeOperation.objects.first()
-        self.login()
-        self.open(
-            reverse(
-                f"admin:{self.firmware_app_label}_upgradeoperation_change", args=[uo.pk]
+        with patch(self._mock_connect, return_value=True):
+            # Create device firmware and upgrade
+            self._create_device_firmware(upgrade=True)
+            uo = UpgradeOperation.objects.first()
+            self.login()
+            self.open(
+                reverse(
+                    f"admin:{self.firmware_app_label}_upgradeoperation_change",
+                    args=[uo.pk],
+                )
             )
-        )
-        self.wait_for_invisibility(By.CSS_SELECTOR, ".submit-row")
+            self.wait_for_invisibility(By.CSS_SELECTOR, ".submit-row")
 
 
 @tag("selenium_tests")

--- a/openwisp_firmware_upgrader/tests/test_tasks.py
+++ b/openwisp_firmware_upgrader/tests/test_tasks.py
@@ -18,51 +18,51 @@ class TestTasks(TestUpgraderMixin, TransactionTestCase):
     _mock_connect = "openwisp_controller.connection.models.DeviceConnection.connect"
 
     @mock.patch(_mock_upgrade, side_effect=SoftTimeLimitExceeded())
-    @mock.patch(_mock_connect, return_value=True)
     @mock.patch(
         "openwisp_firmware_upgrader.base.models.AbstractUpgradeOperation.upgrade",
         side_effect=SoftTimeLimitExceeded(),
     )
     @capture_any_output()
     def test_upgrade_firmware_timeout(self, *args):
-        device_fw = self._create_device_firmware(upgrade=True)
-        self.assertEqual(UpgradeOperation.objects.count(), 1)
-        uo = device_fw.image.upgradeoperation_set.first()
-        self.assertEqual(uo.status, "failed")
-        self.assertIn("Operation timed out.", uo.log)
+        with mock.patch(self._mock_connect, return_value=True):
+            device_fw = self._create_device_firmware(upgrade=True)
+            self.assertEqual(UpgradeOperation.objects.count(), 1)
+            uo = device_fw.image.upgradeoperation_set.first()
+            self.assertEqual(uo.status, "failed")
+            self.assertIn("Operation timed out.", uo.log)
 
     @mock.patch(_mock_upgrade, return_value=True)
-    @mock.patch(_mock_connect, return_value=True)
     @mock.patch(
         "openwisp_firmware_upgrader.base.models.AbstractDeviceFirmware.create_upgrade_operation",
         side_effect=SoftTimeLimitExceeded(),
     )
     @capture_any_output()
     def test_batch_upgrade_timeout(self, *args):
-        env = self._create_upgrade_env()
-        batch = BatchUpgradeOperation.objects.create(build=env["build2"])
-        # will be executed synchronously due to CELERY_IS_EAGER = True
-        tasks.batch_upgrade_operation.delay(batch_id=batch.pk, firmwareless=False)
-        self.assertEqual(BatchUpgradeOperation.objects.count(), 1)
-        batch = BatchUpgradeOperation.objects.first()
-        self.assertEqual(batch.status, "failed")
+        with mock.patch(self._mock_connect, return_value=True):
+            env = self._create_upgrade_env()
+            batch = BatchUpgradeOperation.objects.create(build=env["build2"])
+            # will be executed synchronously due to CELERY_IS_EAGER = True
+            tasks.batch_upgrade_operation.delay(batch_id=batch.pk, firmwareless=False)
+            self.assertEqual(BatchUpgradeOperation.objects.count(), 1)
+            batch = BatchUpgradeOperation.objects.first()
+            self.assertEqual(batch.status, "failed")
 
     @mock.patch(_mock_upgrade, return_value=True)
-    @mock.patch(_mock_connect, return_value=True)
     @mock.patch("logging.Logger.warning")
     def test_upgrade_firmware_resilience(self, mocked_logger, *args):
-        upgrade_op_id = UpgradeOperation().id
-        tasks.upgrade_firmware.run(upgrade_op_id)
-        mocked_logger.assert_called_with(
-            f"The UpgradeOperation object with id {upgrade_op_id} has been deleted"
-        )
+        with mock.patch(self._mock_connect, return_value=True):
+            upgrade_op_id = UpgradeOperation().id
+            tasks.upgrade_firmware.run(upgrade_op_id)
+            mocked_logger.assert_called_with(
+                f"The UpgradeOperation object with id {upgrade_op_id} has been deleted"
+            )
 
     @mock.patch(_mock_upgrade, return_value=True)
-    @mock.patch(_mock_connect, return_value=True)
     @mock.patch("logging.Logger.warning")
     def test_batch_upgrade_operation_resilience(self, mocked_logger, *args):
-        batch_id = BatchUpgradeOperation().id
-        tasks.batch_upgrade_operation.run(batch_id=batch_id, firmwareless=False)
-        mocked_logger.assert_called_with(
-            f"The BatchUpgradeOperation object with id {batch_id} has been deleted"
-        )
+        with mock.patch(self._mock_connect, return_value=True):
+            batch_id = BatchUpgradeOperation().id
+            tasks.batch_upgrade_operation.run(batch_id=batch_id, firmwareless=False)
+            mocked_logger.assert_called_with(
+                f"The BatchUpgradeOperation object with id {batch_id} has been deleted"
+            )


### PR DESCRIPTION
## Checklist

- [X] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [ ] I have manually tested the changes proposed in this pull request.
- [X] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Continuing #397 and #434 set of changes to use overridable context manager rather than decorators for connection

## Description of Changes

This is for test_selenium and test_tasks

