### PR TITLE
[fix] Guard admin reverse and template url behind FIRMWARE_UPGRADER_API #444

### DIFF
--- a/openwisp_firmware_upgrader/admin.py
+++ b/openwisp_firmware_upgrader/admin.py
@@ -28,6 +28,7 @@ from openwisp_controller.config.admin import DeactivatedDeviceReadOnlyMixin, Dev
 from openwisp_users.multitenancy import MultitenantAdminMixin, MultitenantOrgFilter
 from openwisp_utils.admin import ReadOnlyAdmin, TimeReadonlyAdminMixin
 
+from . import settings as app_settings
 from .filters import (
     BuildCategoryFilter,
     BuildCategoryOrganizationFilter,
@@ -434,9 +435,13 @@ class UpgradeOperationAdmin(BaseUpgradeAdmin):
 
     def change_view(self, request, object_id, extra_context=None, **kwargs):
         extra_context = extra_context or {}
-        extra_context["upgrade_operation_cancel_url"] = reverse(
-            "upgrader:api_upgradeoperation_cancel",
-            args=["00000000-0000-0000-0000-000000000000"],
+        extra_context["upgrade_operation_cancel_url"] = (
+            reverse(
+                "upgrader:api_upgradeoperation_cancel",
+                args=["00000000-0000-0000-0000-000000000000"],
+            )
+            if app_settings.FIRMWARE_UPGRADER_API
+            else ""
         )
         extra_context["django_locale"] = get_language()
         obj = self.get_object(request, object_id)

--- a/openwisp_firmware_upgrader/admin.py
+++ b/openwisp_firmware_upgrader/admin.py
@@ -813,6 +813,13 @@ class DeviceFirmwareInline(
 
     def get_formset(self, request, obj=None, **kwargs):
         formset = super().get_formset(request, obj=obj, **kwargs)
+        if app_settings.FIRMWARE_UPGRADER_API:
+            formset.upgrade_operation_cancel_url = reverse(
+                "upgrader:api_upgradeoperation_cancel",
+                args=["00000000-0000-0000-0000-000000000000"],
+            )
+        else:
+            formset.upgrade_operation_cancel_url = ""
         if obj:
             try:
                 schema = get_upgrader_schema_for_device(obj)

--- a/openwisp_firmware_upgrader/static/firmware-upgrader/js/upgrade-progress.js
+++ b/openwisp_firmware_upgrader/static/firmware-upgrader/js/upgrade-progress.js
@@ -260,7 +260,10 @@ function updateStatusWithProgressBar(statusField, operation) {
         ${escapeHtml(progressPercentage)}%
       </span>
     `;
-    const canCancel = progressPercentage < 65;
+    const canCancel =
+      progressPercentage < 65 &&
+      typeof owUpgradeOperationCancelUrl !== "undefined" &&
+      owUpgradeOperationCancelUrl !== "";
     const cancelButtonClass = canCancel
       ? "upgrade-cancel-btn"
       : "upgrade-cancel-btn disabled";

--- a/openwisp_firmware_upgrader/static/firmware-upgrader/js/upgrade-progress.js
+++ b/openwisp_firmware_upgrader/static/firmware-upgrader/js/upgrade-progress.js
@@ -260,10 +260,7 @@ function updateStatusWithProgressBar(statusField, operation) {
         ${escapeHtml(progressPercentage)}%
       </span>
     `;
-    const canCancel =
-      progressPercentage < 65 &&
-      typeof owUpgradeOperationCancelUrl !== "undefined" &&
-      owUpgradeOperationCancelUrl !== "";
+    const canCancel = progressPercentage < 65 && Boolean(owUpgradeOperationCancelUrl);
     const cancelButtonClass = canCancel
       ? "upgrade-cancel-btn"
       : "upgrade-cancel-btn disabled";

--- a/openwisp_firmware_upgrader/templates/admin/firmware_upgrader/device_firmware_inline.html
+++ b/openwisp_firmware_upgrader/templates/admin/firmware_upgrader/device_firmware_inline.html
@@ -5,5 +5,5 @@ var firmwareUpgraderSchema = {{ inline_admin_formset.formset.extra_context | def
 var owFirmwareUpgraderApiHost = {
     host: "{{ request.get_host|escapejs }}"
 };
-var owUpgradeOperationCancelUrl = "{% url 'upgrader:api_upgradeoperation_cancel' '00000000-0000-0000-0000-000000000000' %}";
+var owUpgradeOperationCancelUrl = "{% url 'upgrader:api_upgradeoperation_cancel' '00000000-0000-0000-0000-000000000000' as cancel_url %}{{ cancel_url|default:'' }}";
 </script>

--- a/openwisp_firmware_upgrader/templates/admin/firmware_upgrader/device_firmware_inline.html
+++ b/openwisp_firmware_upgrader/templates/admin/firmware_upgrader/device_firmware_inline.html
@@ -5,5 +5,5 @@ var firmwareUpgraderSchema = {{ inline_admin_formset.formset.extra_context | def
 var owFirmwareUpgraderApiHost = {
     host: "{{ request.get_host|escapejs }}"
 };
-var owUpgradeOperationCancelUrl = "{% url 'upgrader:api_upgradeoperation_cancel' '00000000-0000-0000-0000-000000000000' as cancel_url %}{{ cancel_url|default:'' }}";
+var owUpgradeOperationCancelUrl = "{{ inline_admin_formset.formset.upgrade_operation_cancel_url }}";
 </script>

--- a/openwisp_firmware_upgrader/tests/test_admin.py
+++ b/openwisp_firmware_upgrader/tests/test_admin.py
@@ -1078,6 +1078,8 @@ class TestAdmin(BaseTestAdmin, TestCase):
             response = self.client.get(change_url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context.get("upgrade_operation_cancel_url"), "")
+        self.assertContains(response, 'var owUpgradeOperationCancelUrl = "";')
+        self.assertNotContains(response, "api_upgradeoperation_cancel")
 
     def test_device_change_page_api_disabled(self):
         self._login()
@@ -1089,6 +1091,8 @@ class TestAdmin(BaseTestAdmin, TestCase):
         with mock.patch.object(app_settings, "FIRMWARE_UPGRADER_API", False):
             response = self.client.get(change_url)
         self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'var owUpgradeOperationCancelUrl = "";')
+        self.assertNotContains(response, "api_upgradeoperation_cancel")
 
 
 class TestAdminTransaction(

--- a/openwisp_firmware_upgrader/tests/test_admin.py
+++ b/openwisp_firmware_upgrader/tests/test_admin.py
@@ -1079,7 +1079,6 @@ class TestAdmin(BaseTestAdmin, TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context.get("upgrade_operation_cancel_url"), "")
         self.assertContains(response, 'var owUpgradeOperationCancelUrl = "";')
-        self.assertNotContains(response, "api_upgradeoperation_cancel")
 
     def test_device_change_page_api_disabled(self):
         self._login()
@@ -1092,7 +1091,6 @@ class TestAdmin(BaseTestAdmin, TestCase):
             response = self.client.get(change_url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'var owUpgradeOperationCancelUrl = "";')
-        self.assertNotContains(response, "api_upgradeoperation_cancel")
 
 
 class TestAdminTransaction(

--- a/openwisp_firmware_upgrader/tests/test_admin.py
+++ b/openwisp_firmware_upgrader/tests/test_admin.py
@@ -27,6 +27,7 @@ from openwisp_firmware_upgrader.admin import (
 from openwisp_users.tests.utils import TestMultitenantAdminMixin
 from openwisp_utils.tests import AdminActionPermTestMixin, capture_stderr
 
+from .. import settings as app_settings
 from ..hardware import REVERSE_FIRMWARE_IMAGE_MAP
 from ..swapper import load_model
 from ..upgraders.openwisp import OpenWisp1
@@ -1065,6 +1066,29 @@ class TestAdmin(BaseTestAdmin, TestCase):
         self.assertNotIn("disabled", failed_delete_input)
         self.assertIn("disabled", in_progress_delete_input)
         self.assertLess(failed_index, in_progress_index)
+
+    def test_upgrade_operation_change_view_api_disabled(self):
+        self._login()
+        device = self._create_device_with_connection()
+        operation = UpgradeOperation.objects.create(device=device)
+        change_url = reverse(
+            f"admin:{self.app_label}_upgradeoperation_change", args=[operation.pk]
+        )
+        with mock.patch.object(app_settings, "FIRMWARE_UPGRADER_API", False):
+            response = self.client.get(change_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context.get("upgrade_operation_cancel_url"), "")
+
+    def test_device_change_page_api_disabled(self):
+        self._login()
+        device_fw = self._create_device_firmware()
+        device = device_fw.device
+        change_url = reverse(
+            f"admin:{self.config_app_label}_device_change", args=[device.pk]
+        )
+        with mock.patch.object(app_settings, "FIRMWARE_UPGRADER_API", False):
+            response = self.client.get(change_url)
+        self.assertEqual(response.status_code, 200)
 
 
 class TestAdminTransaction(


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #444 


## Changes

Guard the `reverse("upgrader:api_upgradeoperation_cancel")` call in the admin and the `{% url %}` tag in the template behind `FIRMWARE_UPGRADER_API`. When the API is disabled, the URL doesn't exist and these cause `NoReverseMatch` — now they gracefully return empty string instead of crashing.

