### PR TITLE
[change] Block firmware upgrades for disabled organizations #445

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,8 @@ jobs:
           pip install -U -e .
           pip install -U ${{ matrix.django-version }}
           sudo npm install -g prettier
+          pip install --upgrade --force-reinstall --no-deps --no-cache-dir https://github.com/openwisp/openwisp-users/tarball/issues/522-disabled-org
+          pip install --upgrade --force-reinstall --no-deps --no-cache-dir https://github.com/openwisp/openwisp-controller/tarball/issues/1393-disabled-org
 
       - name: Start redis
         if: ${{ !cancelled() && steps.deps.conclusion == 'success' }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,8 @@ If instructions conflict, repository config and CI workflows win first, official
 
 - Watch for cross-tenant data leaks, permission bypasses, unsafe file paths, unsafe downloads, insecure firmware handling, and secrets.
 - Preserve validation around firmware images, checksums, metadata, private storage paths, upgrade commands, and URLs.
+- Objects belonging to a disabled organization must be readable and deletable; creation and updates must be blocked across all relevant write paths. This applies to objects with either a direct or chained/nested relationship to the organization. No other operations should be permitted, except for ordinary cleanup operations.
+- Operations on deactivated devices must be blocked, except for read-only access and cleanup operations required to maintain consistency. Creation, updates, provisioning, configuration, and other mutating operations must not be performed for deactivated devices.
 
 ## Troubleshooting
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,525 @@
+# Plan: Enforce disabled-organization and deactivated-device rules in openwisp-firmware-upgrader
+
+Implements https://github.com/openwisp/openwisp-firmware-upgrader/issues/445 plus the
+deactivated-device gaps still open in the decision matrix (follow-up of the closed #382).
+
+> Target executor: AI agent using the Sonnet model. Follow the steps in order.
+> Everything here was verified against the working tree at commit `bbec0e7`.
+
+---
+
+## 1. Context
+
+OpenWISP is rolling out two related policies across modules:
+
+- **Deactivated devices** (`Device._is_deactivated`): no new network or management
+  operations may target them. Read and cleanup stay available.
+- **Disabled organizations** (`Organization.is_active == False`): objects stay readable
+  and deletable, but create and update are blocked; queued background work must
+  revalidate before running.
+
+`openwisp-users` PR #544 (branch `issues/522-disabled-org`, checked out at
+`~/openwisp/openwisp-users`) provides the shared primitives, and `openwisp-controller`
+PR #1456 (branch `issues/1393-disabled-org`, at `~/openwisp/openwisp-controller`)
+implements the policy for devices. Both are installed as editable packages in
+`~/openwisp/venv-firmware-upgrader`, so their behavior is live in this repo's test runs.
+
+This repo already implements most of the deactivated-device policy. It has **zero**
+references to organization `is_active`. The goal of this change is to close the
+disabled-organization gap and the few remaining deactivated-device gaps, with tests
+covering every row of `var/firmware-upgrader-matrix.csv`.
+
+**Outcome:** upgrades cannot be created or executed for devices in disabled
+organizations; mass upgrades exclude them; queued workers revalidate; reads, deletes,
+cancellation, status aggregation and cleanup keep working.
+
+---
+
+## 1b. Companion deliverable: cross-module reference file
+
+**Already written** at
+`var/openwisp-org-device-state-reference.md` (gitignored, so it does not leak into a PR).
+It catalogues every reusable primitive introduced by openwisp-users PR #544 and
+openwisp-controller PR #1456 (dotted import paths, signatures, opt-out flags), the agreed
+policy semantics (blocked vs. allowed operations, expected HTTP/admin status codes), the
+upstream test helper recipes, and known gaps/traps (e.g. `DisabledOrgReadOnly` never
+blocking POST, serializer MRO requirements, the best-effort nature of
+`deactivate_organization_devices`). Read it before starting implementation instead of
+re-deriving these facts from the two upstream branches.
+
+---
+
+## 2. Setup
+
+```bash
+cd /home/pandafy/openwisp/openwisp-firmware-upgrader
+source ~/openwisp/venv-firmware-upgrader/bin/activate
+git checkout -b issues/445-disabled-org master
+```
+
+Read `AGENTS.md` first. It is binding. Key points for this change:
+
+- Focused tests: `./runtests.py -k <dotted.path> --no-input --failfast --verbosity=2`
+  (add `--parallel` when running more than one TestCase class).
+- Run `openwisp-qa-format` after each change, and `./run-qa-checks` before finishing.
+- Commit subject: past tense, ends with `#445`, e.g.
+  `[change] Limited firmware upgrade operations on disabled organizations #445`.
+- Do not edit `CHANGES.rst`; the releaser publishes commit subjects automatically.
+
+**Documentation is deliberately out of scope** for this change (user decision). Mark the
+docs checklist item N/A in the PR. Note that AGENTS.md normally requires a docs update
+for user-facing behavior changes, so a follow-up may be requested.
+
+---
+
+## 3. What already works: do not reimplement
+
+Verified in the live tree. Reuse these instead of writing new code.
+
+### Already handled by openwisp-users PR #544 (inherited, no code needed here)
+
+| Mechanism                                                                             | Where                                                                | Effect on this repo                                                                                                                                                                                                                                                                                      |
+| ------------------------------------------------------------------------------------- | -------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ProtectedAPIMixin.permission_classes` now includes `DisabledOrgReadOnly`             | `openwisp_users/api/mixins.py:347`                                   | `openwisp_firmware_upgrader/api/views.py:48` inherits it and does **not** override `permission_classes`, so PUT/PATCH on Category, Build, FirmwareImage, BatchUpgradeOperation, DeviceFirmware objects of a disabled org returns 403. DELETE and reads stay allowed.                                     |
+| `FilterSerializerByOrgManaged._filter_organization_field` / `_filter_related_field`   | `openwisp_users/api/mixins.py:210-231`                               | `BaseSerializer` (`api/serializers.py:22`) already inherits it, so **create** into a disabled org returns 400 with `"Organization with pk ... does not exist or is disabled."` This also filters `group`/`location` in `BatchUpgradeSerializer`.                                                         |
+| `MultitenantAdminMixin.has_change_permission` / `get_inline_instances` / `_edit_form` | `openwisp_users/multitenancy.py:80-170`                              | `BaseAdmin` and `BaseVersionAdmin` (`admin.py:69,73`) inherit it, so Category/Build/BatchUpgradeOperation change forms are 403 for disabled orgs, org selectors exclude disabled orgs, and the firmware inlines on the controller `DeviceAdmin` become add/change-disabled while delete stays available. |
+| `organizations_managed` excludes disabled orgs                                        | `openwisp_users/base/models.py:152`                                  | Non-superusers lose list/detail visibility of disabled-org objects everywhere for free.                                                                                                                                                                                                                  |
+| Controller cascade: disabling an org deactivates all its devices                      | `openwisp_controller/config/handlers.py:190` + `config/tasks.py:226` | The existing `is_deactivated()` guards in this repo catch most cases already. The org checks added below close the race window and the shared-category case.                                                                                                                                             |
+
+### Already handled in this repo (deactivated devices)
+
+- `AbstractDeviceFirmware.clean` raises `DEACTIVATED_DEVICE_FIRMWARE_ERROR` (`base/models.py:405`).
+- `AbstractUpgradeOperation.clean` raises `DEACTIVATED_DEVICE_UPGRADE_OPERATION_ERROR` (`base/models.py:860`).
+- `AbstractUpgradeOperation.upgrade()` aborts on deactivated devices (`base/models.py:939`).
+  Because Celery retries re-enter `upgrade()`, **the "no re-check before retry" gap in the
+  matrix is already closed**; the same code path will cover organizations after step 5.
+- `_find_related_device_firmwares` excludes `device___is_deactivated=True` (`base/models.py:219`).
+- `_find_firmwareless_devices` excludes `_is_deactivated=True` (`base/models.py:241`).
+- `DeviceFirmwareDetailView.get_object` blocks writes and PUT-as-create for deactivated
+  devices (`api/views.py:384,392`). **The matrix's "PUT-as-create bypass" note is stale.**
+- `DeviceFirmwareInline` uses `DeactivatedDeviceReadOnlyMixin` (`admin.py:802`).
+
+Updating `var/firmware-upgrader-matrix.csv` is **not** required; leave it as the source
+document.
+
+---
+
+## 4. Design decisions (agreed with the user)
+
+1. **Execution-time re-check only.** Do not connect a receiver for
+   `openwisp_users.signals.organization_disabled`. The controller already deactivates the
+   org's devices, and the guards added to `UpgradeOperation.upgrade()` and
+   `BatchUpgradeOperation.upgrade()` re-validate when the worker actually runs. This
+   mirrors `openwisp_controller/config/whois/tasks.py:75` and
+   `geo/estimated_location/tasks.py:32`.
+2. **Terminal status for a blocked in-flight operation is `aborted`**, not `cancelled`.
+   `STATUS_CHOICES` documents `aborted` as "aborted due to prerequisites not met"
+   (`base/models.py:827`), and the existing deactivated-device abort already uses it.
+   `cancelled` stays reserved for explicit user cancellation.
+   The one exception is a **batch** that ends up with zero operations: it is marked
+   `cancelled` so it reaches a terminal state instead of hanging in `in-progress`.
+3. **Direct writes raise; bulk resolution silently excludes.** Assigning a
+   `DeviceFirmware` or creating an `UpgradeOperation` for a disabled org raises
+   `ValidationError` (consistent with the deactivated-device handling in this repo).
+   Mass-upgrade target queries filter the rows out silently (consistent with
+   `openwisp_controller/pki/admin.py:18`).
+4. **Shared categories:** a shared category (`organization_id is None`) can still be used
+   for mass upgrades, but devices of disabled organizations are excluded from the target
+   queries. A category owned by a disabled organization rejects upgrade initiation
+   outright.
+5. **Read, delete, cancel, status aggregation and file cleanup are never blocked.** Do not
+   add guards to `AbstractUpgradeOperation.cancel`, `log_line`, `update_progress`,
+   `calculate_and_update_status`, the websocket publishers, or
+   `delete_firmware_files` / `_remove_file`.
+
+---
+
+## 5. Implementation
+
+Work TDD where the behavior is unambiguous: for each step below, add the failing test
+from section 6 first, then the code.
+
+### Step 1: `openwisp_firmware_upgrader/constants.py`
+
+Add two constants alongside the existing deactivated-device ones, same naming style:
+
+```python
+DISABLED_ORGANIZATION_FIRMWARE_ERROR = _(
+    "Firmware upgrades are not allowed for disabled organizations."
+)
+DISABLED_ORGANIZATION_UPGRADE_OPERATION_ERROR = _(
+    "Upgrade operations are not allowed for disabled organizations."
+)
+```
+
+### Step 2: `base/models.py` validation guards
+
+Import the new constants next to the existing ones (`base/models.py:22-25`).
+
+- **`AbstractDeviceFirmware.clean`** (line 402): immediately after the
+  `self.device.is_deactivated()` check, add:
+
+  ```python
+  if not self.device.organization.is_active:
+      raise ValidationError(DISABLED_ORGANIZATION_FIRMWARE_ERROR)
+  ```
+
+  The device organization is authoritative here: `clean()` already rejects a mismatch
+  between the image category organization and the device organization, and for shared
+  categories the device organization is the only meaningful one.
+
+- **`AbstractUpgradeOperation.clean`** (line 858): mirror the same pattern using
+  `DISABLED_ORGANIZATION_UPGRADE_OPERATION_ERROR`, keeping the existing
+  `hasattr(self, "device") and self.device` guard.
+
+These two cover the whole `DeviceFirmware.save(upgrade=True)` -> `create_upgrade_operation`
+-> `operation.full_clean()` chain (`base/models.py:446-473`), which is the shared path
+for the REST API, the admin inline and batch expansion. No separate guard is needed in
+`create_upgrade_operation`.
+
+### Step 3: `base/models.py` target-resolution queries
+
+- **`_find_related_device_firmwares`** (line 213): add
+  `.filter(device__organization__is_active=True)` next to the existing
+  `.exclude(device___is_deactivated=True)`.
+- **`_find_firmwareless_devices`** (line 238): add `organization__is_active=True` to the
+  `Device.objects.filter(...)` call.
+
+This single change covers the preview (`dry_run`), the admin confirmation page, the REST
+dry-run endpoint, `upgrade_related_devices` and `upgrade_firmwareless_devices`, because
+they all resolve targets through these two methods. It also gives the shared-category
+behavior required by the matrix.
+
+Add `select_related("device__organization")` where `select_devices=True` in
+`_find_related_device_firmwares` so the added join does not turn into an N+1 in the
+confirmation page.
+
+### Step 4: `AbstractBuild.batch_upgrade` (line 174)
+
+Before the `dry_run` call, reject initiation when the category belongs to a disabled
+organization:
+
+```python
+if self.category.organization_id and not self.category.organization.is_active:
+    raise ValidationError(DISABLED_ORGANIZATION_FIRMWARE_ERROR)
+```
+
+This is the single choke point for both entrypoints: `BuildBatchUpgradeView.post`
+(`api/views.py:125-132`) already converts `ValidationError` into a 400 response, and
+`BuildAdmin.upgrade_selected` (`admin.py:260-263`) already converts it into an admin error
+message. No changes are needed in either caller for this behavior.
+
+### Step 5: `AbstractUpgradeOperation.upgrade` (line 935)
+
+Extend the existing early-abort block. Keep the deactivated-device branch as it is and add
+a second one so the log line names the real reason:
+
+```python
+if not self.device.organization.is_active:
+    self.status = "aborted"
+    self.log_line(
+        _("Upgrade aborted because the organization has been disabled."),
+        save=False,
+    )
+    self.save()
+    return
+```
+
+Place it directly after the `is_deactivated()` branch. This is the execution-time
+revalidation required by the issue: `tasks.upgrade_firmware` calls `upgrade()` on every
+attempt including Celery retries, so no guard is needed inside the task itself.
+
+### Step 6: `AbstractBatchUpgradeOperation.upgrade` (line 615)
+
+Two changes:
+
+1. At the start, before setting `in-progress`, bail out when the build's category
+   organization has been disabled since the batch was scheduled:
+
+   ```python
+   if self.build.category.organization_id and not self.build.category.organization.is_active:
+       self.status = "cancelled"
+       self.save()
+       return
+   ```
+
+2. At the end, after `upgrade_related_devices()` and the optional
+   `upgrade_firmwareless_devices()`, mark the batch terminal when nothing was queued:
+
+   ```python
+   if not self.upgradeoperation_set.exists():
+       self.status = "cancelled"
+       self.save(update_fields=["status"])
+   ```
+
+   This is required because `calculate_and_update_status` returns `self.status` unchanged
+   when there are zero operations (`base/models.py:804-811`), so a batch whose targets all
+   became deactivated or disabled would otherwise stay `in-progress` forever. Do **not**
+   use the `total_operations` cached property here; it may have been populated earlier in
+   the request.
+
+### Step 7: auto-creation paths (deactivated-device gaps from the matrix)
+
+- **`AbstractDeviceFirmware.create_for_device`** (line 475): add an early return at the
+  top of the method:
+
+  ```python
+  if device.is_deactivated() or not device.organization.is_active:
+      return
+  ```
+
+  This is the authoritative guard for both Celery auto-creation tasks. It also removes the
+  current behavior where every deactivated device produces a `logger.warning` from the
+  swallowed `ValidationError` at line 504.
+
+- **`AbstractDeviceFirmware.auto_add_device_firmware_to_device`** (line 510): add the same
+  condition as an early return before `transaction.on_commit(...)`, so no pointless task
+  is queued when a `DeviceConnection` is created for a deactivated device or a device in a
+  disabled organization.
+
+- **`tasks.create_all_device_firmwares`** (`tasks.py:83`): narrow the queryset so the task
+  does not iterate the whole device table:
+
+  ```python
+  queryset = Device.objects.filter(
+      os=fw_image.build.os,
+      _is_deactivated=False,
+      organization__is_active=True,
+  ).select_related("organization")
+  ```
+
+  The `create_for_device` guard stays as the invariant; this filter is the efficiency
+  counterpart, so add a short comment saying so.
+
+### Step 8: `api/views.py` PUT-as-create hole
+
+In `DeviceFirmwareDetailView.get_object` (line 374), the PUT-as-create branch never reaches
+`DisabledOrgReadOnly.has_object_permission` (DRF only calls it when an object exists).
+Extend the existing deactivated-device check to cover the organization, mirroring
+`openwisp_controller/geo/api/views.py:206`:
+
+```python
+if self._device.is_deactivated():
+    raise PermissionDenied(DEACTIVATED_DEVICE_FIRMWARE_ERROR)
+if not self._device.organization.is_active:
+    raise PermissionDenied(DISABLED_ORGANIZATION_FIRMWARE_ERROR)
+```
+
+The existing-object branch at line 392 needs no change: `DisabledOrgReadOnly` already
+covers it via `organization_field = "device__organization"` (line 306).
+
+Add `"device__organization"` to the `select_related` of the `DeviceFirmwareDetailView`
+queryset (line 303) to keep the query count flat.
+
+Leave `UpgradeOperationCancelView` untouched: cancellation must stay available (matrix row
+`upgrade.operation.cancel`).
+
+### Step 9: `admin.py`
+
+- **`BuildAdmin.upgrade_selected`** (line 202): add an early check right after the
+  `queryset.count() > 1` guard, so the user gets a clear message instead of an empty
+  confirmation page. Follow `openwisp_controller/config/admin.py:742`:
+
+  ```python
+  build = queryset.first()
+  if build.category.organization_id and not build.category.organization.is_active:
+      self.message_user(
+          request,
+          _("Cannot start a mass upgrade for a disabled organization."),
+          messages.ERROR,
+      )
+      return None
+  ```
+
+  Move the existing `build = queryset.first()` assignment (line 224) above this check.
+  `batch_upgrade` (step 4) remains the authoritative guard.
+
+- **`BatchUpgradeConfirmationForm.__init__`** (line 138): add
+  `organization__is_active=True` to both `device_group_qs` and `location_qs`, so a shared
+  category cannot be scoped to a group or location of a disabled organization. The REST
+  equivalent is already handled by `FilterSerializerByOrgManaged`.
+
+- **`DeviceUpgradeOperationInline`** (line 865): add
+  `DeactivatedDeviceReadOnlyMixin` to the bases, matching `DeviceFirmwareInline`
+  (line 802). It is currently read-only only by virtue of `readonly_fields = fields` and an
+  inherited `has_add_permission`, which is implicit rather than enforced.
+
+**Do not** add `multitenant_parent` to `UpgradeOperationAdmin`. Its absence
+(`admin.py:423`) is pre-existing and unrelated to this issue; flag it to the user as a
+possible follow-up rather than fixing it here.
+
+---
+
+## 6. Tests
+
+Every row of `var/firmware-upgrader-matrix.csv` must end up covered. Add assertions to the
+**existing** test classes rather than creating new ones.
+
+### Wiring the shared helpers
+
+- `openwisp_firmware_upgrader/tests/test_admin.py`: `BaseTestAdmin` already inherits
+  `TestMultitenantAdminMixin`, which now inherits
+  `openwisp_users.tests.utils.TestDisabledOrgAdminMixin`. The helpers are available with
+  no import change.
+- `openwisp_firmware_upgrader/tests/test_api.py`: add
+  `from openwisp_users.tests.test_api import TestDisabledOrgApiMixin` and mix it into
+  `TestAPIUpgraderMixin` (line 45).
+
+Helper signatures (verified):
+
+```python
+_test_disabled_org_api_crud(
+    obj, detail_url, list_url=None, create_payload=None, update_payload=None,
+    roles=("org_admin", "superuser"),
+    operations=("list", "retrieve", "create", "update", "delete"),
+    org_admin_expected=None, superuser_expected=None,
+    auth_mechanism="bearer", unchanged_field="name", organization=None,
+)
+_test_disabled_org_admin_crud(
+    obj, change_data, roles=("org_admin", "superuser"),
+    operations=("view", "change", "delete"), organization=None,
+    org_admin_expected=None, superuser_expected=None, unchanged_field="name",
+)
+_test_disabled_org_admin_inline_readonly(
+    model_admin, disabled_obj, active_obj=None,
+    inline_models=None, inline_admins=None, user=None,
+)
+_test_disabled_org_admin_org_field_excludes_disabled(url, disabled_org, roles=("superuser",), ...)
+```
+
+Default expectations encoded by the helpers: API superuser gets list 200 / retrieve 200 /
+create 400 / update 403 / delete 204; API org_admin gets 403 everywhere. Admin superuser
+gets view 200 / change 403 / delete 200; admin org_admin gets view 302 / change 200
+unchanged / delete 200 still present. Pass `org_admin_expected` or `superuser_expected`
+only where firmware-upgrader genuinely differs, and say why in a comment.
+
+Setup idiom used across OpenWISP: create the objects while the organization is active,
+then disable it so the signal path runs.
+
+```python
+org.is_active = False
+org.save(update_fields=["is_active"])
+```
+
+`unchanged_field` must be set per model: `Category` has `name`, `Build` has `version`,
+`FirmwareImage` has `type`.
+
+### Coverage map
+
+| Matrix operation                                                                              | Test file / class                                                                                                                                                                                                                                                                        | What to assert                                                                                                                                                                                                                                                                             |
+| --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `category.manage`, `build.manage`, `image.register`                                           | `test_api.py` (`TestCategoryViews`, `TestBuildViews`, `TestFirmwareImageViews`), `test_admin.py` (`TestAdmin`)                                                                                                                                                                           | `_test_disabled_org_api_crud` and `_test_disabled_org_admin_crud` for each model. Confirms the inherited upstream guards actually hold in this repo.                                                                                                                                       |
+| `automation.image.fanout_device_firmware`                                                     | `test_tasks.py::TestTasks`                                                                                                                                                                                                                                                               | Create an image after deactivating a device / disabling an org; assert `DeviceFirmware.objects.filter(device=...).count() == 0`. Use `subTest` for the two cases.                                                                                                                          |
+| `automation.connection.autolink_device_firmware`                                              | `test_tasks.py::TestTasks`                                                                                                                                                                                                                                                               | Create a `DeviceConnection` for a deactivated device and for a device in a disabled org; assert no `DeviceFirmware` was created and (with `mock.patch`) that `create_device_firmware.delay` was not called.                                                                                |
+| `device-firmware.assign`                                                                      | `test_models.py::TestModels` (extend `test_deactivated_device_validation` at line 1141), `test_api.py` (extend `test_deactivated_device` at 1356 and `test_deactivated_device_put_as_create` at 1385), `test_admin.py` (extend `test_device_firmware_inline_deactivated_device` at 2076) | Model: `assertRaises(ValidationError)` with `DISABLED_ORGANIZATION_FIRMWARE_ERROR`. API: PUT/PATCH -> 403, PUT-as-create -> 403, DELETE -> allowed. Admin: inline add/change disabled, delete allowed via `_test_disabled_org_admin_inline_readonly` against the controller `DeviceAdmin`. |
+| `device-firmware.read`                                                                        | `test_api.py`                                                                                                                                                                                                                                                                            | GET on the device firmware detail endpoint still returns 200 for a disabled org and a deactivated device.                                                                                                                                                                                  |
+| `upgrade.operation.progress_persist`, `batch.status.recalculate`, `realtime.progress.publish` | `test_models.py::TestModels`, `test_websockets.py`                                                                                                                                                                                                                                       | Disable the org **after** operations exist, then assert `log_line`, `update_progress` and `calculate_and_update_status` still work and the batch reaches a terminal status.                                                                                                                |
+| `upgrade.operation.retry`                                                                     | `test_models.py::TestModelsTransaction`                                                                                                                                                                                                                                                  | Disable the org mid-upgrade, re-enter `upgrade()`, assert status `aborted` and the abort log line, and that no further retry is scheduled.                                                                                                                                                 |
+| `upgrade.operation.cancel`                                                                    | `test_api.py` (cancel view tests, from line 2072)                                                                                                                                                                                                                                        | Cancel still returns 200 for an in-progress operation whose org was disabled and whose device was deactivated.                                                                                                                                                                             |
+| `upgrade.operation.create`                                                                    | `test_models.py::TestModels`                                                                                                                                                                                                                                                             | `DeviceFirmware.save(upgrade=True)` for a disabled org raises `ValidationError`, and `UpgradeOperation.objects.count()` is unchanged.                                                                                                                                                      |
+| `upgrade.operation.execute`, `async.upgrade.worker_run`                                       | `test_models.py::TestModels` (extend `test_upgrade_operation_aborts_when_device_deactivated_before_worker_runs` at line 345), `test_tasks.py`                                                                                                                                            | Disable the org after the operation is created, run `upgrade_firmware`, assert status `aborted`, the log line, and that no `DeviceConnection` was attempted (`mock.patch` on `get_working_connection`, `assert_not_called`).                                                               |
+| `batch.upgrade.preview`                                                                       | `test_api.py` (extend `test_build_upgradeable_excludes_deactivated_devices` at line 357), `test_admin.py`                                                                                                                                                                                | Dry-run excludes devices of disabled orgs for a shared category; a disabled-org category returns 400 on POST.                                                                                                                                                                              |
+| `batch.upgrade.schedule`                                                                      | `test_models.py::TestModels` (extend `test_batch_upgrade_excludes_deactivated_devices` at line 1085), `test_api.py`, `test_admin.py`                                                                                                                                                     | `batch_upgrade` on a disabled-org build raises `ValidationError`; API returns 400; the admin action shows the error message and creates no `BatchUpgradeOperation`.                                                                                                                        |
+| `batch.upgrade.execute_related`, `batch.upgrade.execute_firmwareless`                         | `test_models.py::TestModelsTransaction`                                                                                                                                                                                                                                                  | With a shared category and two orgs (one disabled), the batch creates operations only for the active org's devices.                                                                                                                                                                        |
+| `async.batch.worker_run`                                                                      | `test_models.py::TestModelsTransaction`                                                                                                                                                                                                                                                  | Disable the org between `batch_upgrade()` and the worker call; assert the batch ends `cancelled` with zero operations, not stuck `in-progress`.                                                                                                                                            |
+| `storage.firmware.asset_delete`, `storage.firmware.file_delete`                               | `test_private_storage.py`, `test_api.py`                                                                                                                                                                                                                                                 | DELETE of a `FirmwareImage` / `Build` / `Category` in a disabled org still succeeds and still schedules file cleanup.                                                                                                                                                                      |
+
+### Test hygiene rules for this repo
+
+- Prefer `self.assertEqual` over `assertTrue` / `assertFalse` / `assertIsNone`.
+- Group near-identical cases (deactivated device vs disabled org) with `subTest`,
+  especially in `TransactionTestCase` classes where setup is expensive. Leave one blank
+  line before each `with self.subTest(...)` only when a method has several of them.
+- No docstrings on test methods whose name already describes the scenario.
+- Keep tests quiet: use `capture_stdout` / `capture_any_output` from `openwisp_utils.tests`
+  where the code under test logs.
+- Adding `device.organization` lookups will change some `assertNumQueries` counts. The
+  `select_related` additions in steps 3 and 8 should absorb most of it. Where a count
+  genuinely must change, change it deliberately and add a brief comment; do not delete the
+  assertion.
+
+### Sample-app suite
+
+AGENTS.md requires tenant-isolation and admin/REST authorization changes to be covered by
+both suites. `tests/openwisp2/sample_firmware_upgrader/tests.py` subclasses
+`TestAdmin`, `TestModels`, `TestModelsTransaction`, `TestTasks` and the API test classes,
+so the new tests are inherited automatically. Verify that no new class needs to be
+imported there, and run the sample-app suite (below). No new migration should be required;
+if `makemigrations --check` complains, stop and report rather than generating one.
+
+---
+
+## 7. Verification
+
+Run focused tests as you go:
+
+```bash
+source ~/openwisp/venv-firmware-upgrader/bin/activate
+
+./runtests.py --no-input --failfast --verbosity=2 \
+  -k openwisp_firmware_upgrader.tests.test_models
+
+./runtests.py --no-input --failfast --verbosity=2 --parallel \
+  -k openwisp_firmware_upgrader.tests.test_api \
+  -k openwisp_firmware_upgrader.tests.test_admin \
+  -k openwisp_firmware_upgrader.tests.test_tasks
+```
+
+Then formatting and QA:
+
+```bash
+openwisp-qa-format
+./run-qa-checks
+```
+
+Sample-app integration suite:
+
+```bash
+SAMPLE_APP=1 ./runtests.py --no-input --failfast --verbosity=2 \
+  -k openwisp2.sample_firmware_upgrader.tests
+```
+
+Manual smoke check of the end-to-end behavior (optional but valuable):
+
+```bash
+./tests/manage.py shell
+# create an org, category, build, image, device with connection and DeviceFirmware
+# then: org.is_active = False; org.save(update_fields=["is_active"])
+# assert: DeviceFirmware(...).full_clean() raises ValidationError
+# assert: build.batch_upgrade(firmwareless=True) raises ValidationError
+# assert: existing UpgradeOperation.upgrade() sets status == "aborted"
+```
+
+**Full suite:** AGENTS.md requires a passing full run before pushing or opening a PR. This
+change touches model validation, tenant isolation and admin/REST authorization, so the
+full suite is mandatory. Do not run it unattended: report to the user and ask them to run
+`./runtests` (20 minute timeout) or to confirm you should.
+
+---
+
+## 8. Files touched
+
+| File                                                                                                                                                | Change                                                                                                                                                                                                                                                                                      |
+| --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `var/openwisp-org-device-state-reference.md`                                                                                                        | new, gitignored cross-module reference (section 1b) — already written                                                                                                                                                                                                                       |
+| `openwisp_firmware_upgrader/constants.py`                                                                                                           | 2 new error message constants                                                                                                                                                                                                                                                               |
+| `openwisp_firmware_upgrader/base/models.py`                                                                                                         | guards in `AbstractDeviceFirmware.clean`, `create_for_device`, `auto_add_device_firmware_to_device`; `AbstractUpgradeOperation.clean` and `upgrade`; `AbstractBuild.batch_upgrade`, `_find_related_device_firmwares`, `_find_firmwareless_devices`; `AbstractBatchUpgradeOperation.upgrade` |
+| `openwisp_firmware_upgrader/tasks.py`                                                                                                               | queryset filter in `create_all_device_firmwares`                                                                                                                                                                                                                                            |
+| `openwisp_firmware_upgrader/api/views.py`                                                                                                           | org check in `DeviceFirmwareDetailView.get_object` PUT-as-create branch; `select_related`                                                                                                                                                                                                   |
+| `openwisp_firmware_upgrader/admin.py`                                                                                                               | early check in `BuildAdmin.upgrade_selected`; active-org filters in `BatchUpgradeConfirmationForm.__init__`; `DeactivatedDeviceReadOnlyMixin` on `DeviceUpgradeOperationInline`                                                                                                             |
+| `openwisp_firmware_upgrader/tests/test_models.py`, `test_api.py`, `test_admin.py`, `test_tasks.py`, `test_private_storage.py`, `test_websockets.py` | new assertions in existing classes                                                                                                                                                                                                                                                          |
+
+No migrations. No new models, settings, signals or dependencies.
+
+---
+
+## 9. Out of scope
+
+- Documentation (user decision; AGENTS.md would normally require it).
+- `CHANGES.rst` (handled by the releaser from the commit subject).
+- `UpgradeOperationAdmin` missing `multitenant_parent` (`admin.py:423`): pre-existing,
+  unrelated. Report it, do not fix it.
+- Any change to `openwisp-users` or `openwisp-controller`. Both are prerequisites already
+  checked out and installed; if a needed primitive turns out to be missing, stop and ask.
+- Updating `var/firmware-upgrader-matrix.csv`. Its stale notes about the PUT-as-create hole
+  and the missing mass-upgrade excludes should be reported to the user, not edited.

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -12,6 +12,9 @@ Requirements
   versions of OpenWrt have not worked at all in our tests
 - Devices must have enough free RAM to be able to upload the new image to
   ``/tmp``
+- Devices must be active. They should not be :ref:`deactivated
+  <controller_deactivated_config_status>` or belong to a :ref:`disabled
+  organization <users_disabled_organization>`.
 
 1. Create a Category
 --------------------

--- a/docs/user/rest-api.rst
+++ b/docs/user/rest-api.rst
@@ -212,9 +212,10 @@ Upgrades all the devices related to the specified build ID.
 
 .. note::
 
-Batch upgrades for builds belonging to disabled organizations are
-    rejected with ``403 Forbidden``. For shared builds, devices belonging to
-    disabled organizations or deactivated devices are skipped.
+    Batch upgrades for builds belonging to disabled organizations are
+    rejected with ``403 Forbidden``. For shared builds, devices belonging
+    to disabled organizations or deactivated devices are skipped.
+
 **Optional Parameters**
 
 The batch upgrade operation accepts the following optional parameters in

--- a/docs/user/rest-api.rst
+++ b/docs/user/rest-api.rst
@@ -212,10 +212,9 @@ Upgrades all the devices related to the specified build ID.
 
 .. note::
 
-    If the firmware category belongs to a disabled organization, the
-    request is rejected with ``403 Forbidden``. For shared categories,
-    devices in disabled organizations are skipped.
-
+Batch upgrades for builds belonging to disabled organizations are
+    rejected with ``403 Forbidden``. For shared builds, devices belonging to
+    disabled organizations or deactivated devices are skipped.
 **Optional Parameters**
 
 The batch upgrade operation accepts the following optional parameters in
@@ -383,8 +382,8 @@ firmware if it does not already exist.
 
 .. note::
 
-    Requests that create or update device firmware for a disabled
-    organization are rejected with ``403 Forbidden``.
+    Requests that create or update firmware for a disabled organization or
+    a deactivated device are rejected with ``403 Forbidden``.
 
 Get Device Firmware Details
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/user/rest-api.rst
+++ b/docs/user/rest-api.rst
@@ -210,6 +210,12 @@ Upgrades all the devices related to the specified build ID.
 
     POST /api/v1/firmware-upgrader/build/{id}/upgrade/
 
+.. note::
+
+    If the firmware category belongs to a disabled organization, the
+    request is rejected with ``403 Forbidden``. For shared categories,
+    devices in disabled organizations are skipped.
+
 **Optional Parameters**
 
 The batch upgrade operation accepts the following optional parameters in
@@ -374,6 +380,11 @@ firmware if it does not already exist.
 .. code-block:: text
 
     PUT /api/v1/firmware-upgrader/device/{device_id}/firmware/
+
+.. note::
+
+    Requests that create or update device firmware for a disabled
+    organization are rejected with ``403 Forbidden``.
 
 Get Device Firmware Details
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/openwisp_firmware_upgrader/admin.py
+++ b/openwisp_firmware_upgrader/admin.py
@@ -139,8 +139,8 @@ class BatchUpgradeConfirmationForm(forms.ModelForm):
         self.user = kwargs.pop("user")
         super().__init__(*args, **kwargs)
         build = self.initial.get("build")
-        device_group_qs = DeviceGroup.objects
-        location_qs = Location.objects
+        device_group_qs = DeviceGroup.objects.filter(organization__is_active=True)
+        location_qs = Location.objects.filter(organization__is_active=True)
         organization_id = None
         if build:
             organization_id = build.category.organization_id
@@ -216,12 +216,19 @@ class BuildAdmin(BaseAdmin):
             )
             # returning None will display the change list page again
             return None
+        build = queryset.first()
+        if build.category.organization_id and not build.category.organization.is_active:
+            self.message_user(
+                request,
+                _("Cannot start a mass upgrade for a disabled organization."),
+                messages.ERROR,
+            )
+            return None
         upgrade_all = request.POST.get("upgrade_all")
         upgrade_related = request.POST.get("upgrade_related")
         upgrade_options = request.POST.get("upgrade_options")
         group_id = request.POST.get("group")
         location_id = request.POST.get("location")
-        build = queryset.first()
         form = BatchUpgradeConfirmationForm(initial={"build": build}, user=request.user)
         # upgrade has been confirmed
         if upgrade_all or upgrade_related:
@@ -862,7 +869,9 @@ class DeviceUpgradeOperationForm(UpgradeOperationForm):
         super().__init__(*args, **kwargs)
 
 
-class DeviceUpgradeOperationInline(ReadonlyUpgradeOptionsMixin, UpgradeOperationInline):
+class DeviceUpgradeOperationInline(
+    DeactivatedDeviceReadOnlyMixin, ReadonlyUpgradeOptionsMixin, UpgradeOperationInline
+):
     verbose_name = _("Recent Firmware Upgrades")
     verbose_name_plural = verbose_name
     formset = DeviceUpgradeOperationFormSet

--- a/openwisp_firmware_upgrader/api/views.py
+++ b/openwisp_firmware_upgrader/api/views.py
@@ -14,7 +14,10 @@ from rest_framework.response import Response
 from rest_framework.utils.serializer_helpers import ReturnDict
 
 from openwisp_firmware_upgrader import private_storage
-from openwisp_firmware_upgrader.constants import DEACTIVATED_DEVICE_FIRMWARE_ERROR
+from openwisp_firmware_upgrader.constants import (
+    DEACTIVATED_DEVICE_FIRMWARE_ERROR,
+    DISABLED_ORGANIZATION_FIRMWARE_ERROR,
+)
 from openwisp_users.api.mixins import FilterByOrganizationManaged, IsOrganizationManager
 from openwisp_users.api.mixins import ProtectedAPIMixin as BaseProtectedAPIMixin
 from openwisp_users.api.permissions import DjangoModelPermissions
@@ -300,7 +303,9 @@ class DeviceFirmwareDetailView(
     RelatedDeviceAPIMixin, generics.RetrieveUpdateDestroyAPIView
 ):
     serializer_class = DeviceFirmwareSerializer
-    queryset = DeviceFirmware.objects.select_related("device", "image")
+    queryset = DeviceFirmware.objects.select_related(
+        "device", "device__organization", "image"
+    )
     lookup_field = "device"
     lookup_url_kwarg = "pk"
     organization_field = "device__organization"
@@ -383,6 +388,8 @@ class DeviceFirmwareDetailView(
                 self.assert_parent_exists()
                 if self._device.is_deactivated():
                     raise PermissionDenied(DEACTIVATED_DEVICE_FIRMWARE_ERROR)
+                if not self._device.organization.is_active:
+                    raise PermissionDenied(DISABLED_ORGANIZATION_FIRMWARE_ERROR)
                 self.check_permissions(clone_request(self.request, "POST"))
                 return None
             else:

--- a/openwisp_firmware_upgrader/api/views.py
+++ b/openwisp_firmware_upgrader/api/views.py
@@ -396,7 +396,11 @@ class DeviceFirmwareDetailView(
                 # PATCH requests where the object does not exist should still
                 # return a 404 response.
                 raise
-        if self.request.method not in ("GET", "HEAD") and obj.device.is_deactivated():
+        if (
+            self.request.method not in ("GET", "HEAD")
+            and obj.device.is_deactivated()
+            and obj.device.organization.is_active
+        ):
             raise PermissionDenied(DEACTIVATED_DEVICE_FIRMWARE_ERROR)
         return obj
 

--- a/openwisp_firmware_upgrader/base/models.py
+++ b/openwisp_firmware_upgrader/base/models.py
@@ -205,20 +205,15 @@ class AbstractBuild(TimeStampedEditableModel):
         )
         return batch
 
-    def _find_related_device_firmwares(
-        self, select_devices=False, group=None, location=None
-    ):
+    def _find_related_device_firmwares(self, group=None, location=None):
         """
         Returns all the DeviceFirmware objects related to the firmware
         category of this build that have not been installed yet
         """
-        related = ["image"]
-        if select_devices:
-            related.append("device__organization")
         qs = (
             load_model("DeviceFirmware")
             .objects.all()
-            .select_related(*related)
+            .select_related("image", "device__organization")
             .filter(
                 image__build__category_id=self.category_id,
                 device__organization__is_active=True,
@@ -254,7 +249,7 @@ class AbstractBuild(TimeStampedEditableModel):
             qs = qs.filter(group=group)
         if location:
             qs = qs.filter(devicelocation__location=location)
-        return qs.order_by("-created")
+        return qs.select_related("organization").order_by("-created")
 
 
 def get_build_directory(instance, filename):
@@ -476,9 +471,12 @@ class AbstractDeviceFirmware(TimeStampedEditableModel):
         # if firwmare image has changed launch upgrade
         # upgrade won't be launched the first time
         if upgrade and (self.image_has_changed or not self.installed):
-            self.installed = False
-            super().save(*args, **kwargs)
-            self.create_upgrade_operation(batch, upgrade_options=upgrade_options or {})
+            with transaction.atomic():
+                self.installed = False
+                super().save(*args, **kwargs)
+                self.create_upgrade_operation(
+                    batch, upgrade_options=upgrade_options or {}
+                )
         else:
             super().save(*args, **kwargs)
         self._update_old_image()
@@ -669,7 +667,7 @@ class AbstractBatchUpgradeOperation(UpgradeOptionsMixin, TimeStampedEditableMode
     @staticmethod
     def dry_run(build, group=None, location=None):
         related_device_fw = build._find_related_device_firmwares(
-            select_devices=True, group=group, location=location
+            group=group, location=location
         )
         firmwareless_devices = build._find_firmwareless_devices(
             group=group, location=location
@@ -767,8 +765,7 @@ class AbstractBatchUpgradeOperation(UpgradeOptionsMixin, TimeStampedEditableMode
         if self.upgrade_operations:
             return get_upgrader_class_for_device(self.upgrade_operations[0].device)
         related_device_fw = (
-            related_device_fw
-            or self.build._find_related_device_firmwares(select_devices=True)
+            related_device_fw or self.build._find_related_device_firmwares()
         )
         if related_device_fw:
             return get_upgrader_class_for_device(related_device_fw.first().device)

--- a/openwisp_firmware_upgrader/base/models.py
+++ b/openwisp_firmware_upgrader/base/models.py
@@ -22,6 +22,8 @@ from .. import settings as app_settings
 from ..constants import (
     DEACTIVATED_DEVICE_FIRMWARE_ERROR,
     DEACTIVATED_DEVICE_UPGRADE_OPERATION_ERROR,
+    DISABLED_ORGANIZATION_FIRMWARE_ERROR,
+    DISABLED_ORGANIZATION_UPGRADE_OPERATION_ERROR,
 )
 from ..exceptions import (
     FirmwareUpgradeOptionsException,
@@ -175,6 +177,8 @@ class AbstractBuild(TimeStampedEditableModel):
         self, firmwareless, upgrade_options=None, group=None, location=None
     ):
         upgrade_options = upgrade_options or {}
+        if self.category.organization_id and not self.category.organization.is_active:
+            raise ValidationError(DISABLED_ORGANIZATION_FIRMWARE_ERROR)
         # Check if there are any devices to upgrade with the given filters
         dry_run_result = load_model("BatchUpgradeOperation").dry_run(
             build=self, group=group, location=location
@@ -209,12 +213,15 @@ class AbstractBuild(TimeStampedEditableModel):
         """
         related = ["image"]
         if select_devices:
-            related.append("device")
+            related.append("device__organization")
         qs = (
             load_model("DeviceFirmware")
             .objects.all()
             .select_related(*related)
-            .filter(image__build__category_id=self.category_id)
+            .filter(
+                image__build__category_id=self.category_id,
+                device__organization__is_active=True,
+            )
             .exclude(image__build=self, installed=True)
             .exclude(device___is_deactivated=True)
             .order_by("-created")
@@ -238,6 +245,7 @@ class AbstractBuild(TimeStampedEditableModel):
         qs = Device.objects.filter(
             devicefirmware__isnull=True,
             model__in=boards,
+            organization__is_active=True,
         ).exclude(_is_deactivated=True)
         if self.category.organization_id:
             qs = qs.filter(organization_id=self.category.organization_id)
@@ -404,6 +412,8 @@ class AbstractDeviceFirmware(TimeStampedEditableModel):
             return
         if self.device.is_deactivated():
             raise ValidationError(DEACTIVATED_DEVICE_FIRMWARE_ERROR)
+        if not self.device.organization.is_active:
+            raise ValidationError(DISABLED_ORGANIZATION_FIRMWARE_ERROR)
         if (
             self.image.build.category.organization is not None
             and self.image.build.category.organization != self.device.organization
@@ -481,6 +491,9 @@ class AbstractDeviceFirmware(TimeStampedEditableModel):
 
         May return ``None`` if it was not possible to create the DeviceFirmware.
         """
+        if device.is_deactivated() or not device.organization.is_active:
+            return
+
         DeviceFirmware = load_model("DeviceFirmware")
         FirmwareImage = load_model("FirmwareImage")
         image_type = REVERSE_FIRMWARE_IMAGE_MAP.get(device.model)
@@ -515,6 +528,11 @@ class AbstractDeviceFirmware(TimeStampedEditableModel):
         if not instance.device.os or not instance.device.model:
             return
         if instance.device.model not in REVERSE_FIRMWARE_IMAGE_MAP:
+            return
+        if (
+            instance.device.is_deactivated()
+            or not instance.device.organization.is_active
+        ):
             return
 
         transaction.on_commit(partial(create_device_firmware.delay, instance.device.pk))
@@ -613,11 +631,21 @@ class AbstractBatchUpgradeOperation(UpgradeOptionsMixin, TimeStampedEditableMode
             )
 
     def upgrade(self, firmwareless):
+        if (
+            self.build.category.organization_id
+            and not self.build.category.organization.is_active
+        ):
+            self.status = "cancelled"
+            self.save()
+            return
         self.status = "in-progress"
         self.save()
         self.upgrade_related_devices()
         if firmwareless:
             self.upgrade_firmwareless_devices()
+        if not self.upgradeoperation_set.exists():
+            self.status = "cancelled"
+            self.save(update_fields=["status"])
 
     @staticmethod
     def dry_run(build, group=None, location=None):
@@ -857,8 +885,11 @@ class AbstractUpgradeOperation(UpgradeOptionsMixin, TimeStampedEditableModel):
 
     def clean(self):
         super().clean()
-        if hasattr(self, "device") and self.device and self.device.is_deactivated():
-            raise ValidationError(DEACTIVATED_DEVICE_UPGRADE_OPERATION_ERROR)
+        if hasattr(self, "device") and self.device:
+            if self.device.is_deactivated():
+                raise ValidationError(DEACTIVATED_DEVICE_UPGRADE_OPERATION_ERROR)
+            if not self.device.organization.is_active:
+                raise ValidationError(DISABLED_ORGANIZATION_UPGRADE_OPERATION_ERROR)
 
     def log_line(self, line, save=True):
         if self.log:
@@ -940,6 +971,14 @@ class AbstractUpgradeOperation(UpgradeOptionsMixin, TimeStampedEditableModel):
             self.status = "aborted"
             self.log_line(
                 _("Upgrade aborted because the device has been deactivated."),
+                save=False,
+            )
+            self.save()
+            return
+        if not self.device.organization.is_active:
+            self.status = "aborted"
+            self.log_line(
+                _("Upgrade aborted because the organization has been disabled."),
                 save=False,
             )
             self.save()

--- a/openwisp_firmware_upgrader/base/models.py
+++ b/openwisp_firmware_upgrader/base/models.py
@@ -22,6 +22,7 @@ from .. import settings as app_settings
 from ..constants import (
     DEACTIVATED_DEVICE_FIRMWARE_ERROR,
     DEACTIVATED_DEVICE_UPGRADE_OPERATION_ERROR,
+    DELETED_FIRMWARE_IMAGE_UPGRADE_OPERATION_ERROR,
     DISABLED_ORGANIZATION_FIRMWARE_ERROR,
     DISABLED_ORGANIZATION_UPGRADE_OPERATION_ERROR,
 )
@@ -304,6 +305,7 @@ class AbstractFirmwareImage(TimeStampedEditableModel):
             raise ValidationError({"type": "Could not find boards for this type"})
 
     def delete(self, *args, **kwargs):
+        self._abort_related_upgrade_operations([self])
         super().delete(*args, **kwargs)
         self._remove_file(self.file.name)
 
@@ -370,6 +372,24 @@ class AbstractFirmwareImage(TimeStampedEditableModel):
         cls.schedule_firmware_file_deletion(build__category__organization=instance)
 
     @classmethod
+    def _abort_related_upgrade_operations(cls, images):
+        """
+        Aborts in-progress upgrade operations which reference the given
+        firmware images, so that workers do not keep flashing a file which
+        is about to be removed from storage.
+        """
+        UpgradeOperation = load_model("UpgradeOperation")
+        queryset = UpgradeOperation.objects.filter(
+            status="in-progress", image__in=images
+        )
+        for operation in queryset.iterator():
+            operation.status = "aborted"
+            operation.log_line(
+                DELETED_FIRMWARE_IMAGE_UPGRADE_OPERATION_ERROR, save=False
+            )
+            operation.save()
+
+    @classmethod
     def schedule_firmware_file_deletion(cls, **filter_kwargs):
         """
         Schedules the deletion of firmware image files in the background.
@@ -380,12 +400,11 @@ class AbstractFirmwareImage(TimeStampedEditableModel):
         # Avoid circular import
         from ..tasks import delete_firmware_files
 
-        files_to_delete = []
-        # Get all firmware images matching the filter criteria
-        queryset = cls.objects.filter(**filter_kwargs)
-        for image in queryset.iterator():
-            if image.file and image.file.name:
-                files_to_delete.append(image.file.name)
+        images = list(cls.objects.filter(**filter_kwargs).iterator())
+        cls._abort_related_upgrade_operations(images)
+        files_to_delete = [
+            image.file.name for image in images if image.file and image.file.name
+        ]
         if files_to_delete:
             # Schedule file deletion after transaction is committed
             transaction.on_commit(partial(delete_firmware_files.delay, files_to_delete))

--- a/openwisp_firmware_upgrader/constants.py
+++ b/openwisp_firmware_upgrader/constants.py
@@ -12,3 +12,6 @@ DISABLED_ORGANIZATION_FIRMWARE_ERROR = _(
 DISABLED_ORGANIZATION_UPGRADE_OPERATION_ERROR = _(
     "Upgrade operations are not allowed for disabled organizations."
 )
+DELETED_FIRMWARE_IMAGE_UPGRADE_OPERATION_ERROR = _(
+    "Upgrade aborted because the firmware image has been deleted."
+)

--- a/openwisp_firmware_upgrader/constants.py
+++ b/openwisp_firmware_upgrader/constants.py
@@ -6,3 +6,9 @@ DEACTIVATED_DEVICE_FIRMWARE_ERROR = _(
 DEACTIVATED_DEVICE_UPGRADE_OPERATION_ERROR = _(
     "Upgrade operations are not allowed for deactivated devices."
 )
+DISABLED_ORGANIZATION_FIRMWARE_ERROR = _(
+    "Firmware upgrades are not allowed for disabled organizations."
+)
+DISABLED_ORGANIZATION_UPGRADE_OPERATION_ERROR = _(
+    "Upgrade operations are not allowed for disabled organizations."
+)

--- a/openwisp_firmware_upgrader/tasks.py
+++ b/openwisp_firmware_upgrader/tasks.py
@@ -79,8 +79,11 @@ def create_all_device_firmwares(self, firmware_image_id):
     Device = swapper.load_model("config", "Device")
 
     fw_image = FirmwareImage.objects.select_related("build").get(pk=firmware_image_id)
-
-    queryset = Device.objects.filter(os=fw_image.build.os)
+    queryset = Device.objects.filter(
+        os=fw_image.build.os,
+        _is_deactivated=False,
+        organization__is_active=True,
+    ).select_related("organization")
     for device in queryset.iterator():
         DeviceFirmware.create_for_device(device, fw_image)
 

--- a/openwisp_firmware_upgrader/tests/base.py
+++ b/openwisp_firmware_upgrader/tests/base.py
@@ -35,6 +35,39 @@ class TestUpgraderMixin(CreateConnectionsMixin):
         for fw in FirmwareImage.objects.all():
             fw.delete()
 
+    def _ensure_default_group_permissions(self):
+        """
+        ``TransactionTestCase`` flushes the database after every test,
+        which deletes the Administrator/Operator groups (and their
+        firmware-upgrader permissions) seeded once by openwisp-users'
+        data migration. Recreate them here so tests relying on those
+        groups keep working regardless of which transactional test in
+        the class ran (and flushed) before this one.
+        """
+        app_label = Build._meta.app_label
+        admin_group, _ = Group.objects.get_or_create(name="Administrator")
+        operator_group, _ = Group.objects.get_or_create(name="Operator")
+        admin_only_models = ["category"]
+        shared_models = [
+            "build",
+            "devicefirmware",
+            "firmwareimage",
+            "batchupgradeoperation",
+            "upgradeoperation",
+        ]
+        for model_name in admin_only_models + shared_models:
+            for action in ("add", "change", "delete", "view"):
+                permission = Permission.objects.get(
+                    codename=f"{action}_{model_name}",
+                    content_type__app_label=app_label,
+                )
+                admin_group.permissions.add(permission)
+        for model_name in shared_models:
+            permission = Permission.objects.get(
+                codename=f"view_{model_name}", content_type__app_label=app_label
+            )
+            operator_group.permissions.add(permission)
+
     def _get_build(self, version="0.1", **kwargs):
         opts = {"version": version}
         opts.update(kwargs)

--- a/openwisp_firmware_upgrader/tests/test_admin.py
+++ b/openwisp_firmware_upgrader/tests/test_admin.py
@@ -165,7 +165,7 @@ class TestAdmin(BaseTestAdmin, TestCase):
     def test_upgrade_intermediate_page_related(self):
         self._login()
         env = self._create_upgrade_env()
-        with self.assertNumQueries(15):
+        with self.assertNumQueries(16):
             r = self.client.post(
                 self.build_list_url,
                 {
@@ -179,7 +179,7 @@ class TestAdmin(BaseTestAdmin, TestCase):
     def test_upgrade_intermediate_page_firmwareless(self):
         self._login()
         env = self._create_upgrade_env(device_firmware=False)
-        with self.assertNumQueries(14):
+        with self.assertNumQueries(15):
             r = self.client.post(
                 self.build_list_url,
                 {
@@ -1100,6 +1100,27 @@ class TestAdminTransaction(
     _mock_upgrade = "openwisp_firmware_upgrader.upgraders.openwrt.OpenWrt.upgrade"
     _mock_connect = "openwisp_controller.connection.models.DeviceConnection.connect"
 
+    def _ensure_administrator_group_permissions(self):
+        Group = swapper.load_model("openwisp_users", "Group")
+        group, _ = Group.objects.get_or_create(name="Administrator")
+        model_names = (
+            "build",
+            "category",
+            "devicefirmware",
+            "firmwareimage",
+            "batchupgradeoperation",
+            "upgradeoperation",
+        )
+        codenames = [
+            f"{action}_{model_name}"
+            for action in ("add", "change", "delete", "view")
+            for model_name in model_names
+        ]
+        permissions = Permission.objects.filter(
+            content_type__app_label=self.app_label, codename__in=codenames
+        )
+        group.permissions.add(*permissions)
+
     @mock.patch(_mock_upgrade, return_value=True)
     def test_upgrade_selected_action_perms(self, *args):
         with mock.patch(self._mock_connect, return_value=True):
@@ -1833,6 +1854,7 @@ class TestAdminTransaction(
     @mock.patch(_mock_upgrade, return_value=True)
     def test_batch_upgrade_confirmation_form_multitenancy(self, *args):
         """Test BatchUpgradeConfirmationForm multitenancy for organization admin vs superuser."""
+        self._ensure_administrator_group_permissions()
         with mock.patch(self._mock_connect, return_value=True):
             # Setup common objects
             org1 = self._get_org()
@@ -2152,7 +2174,7 @@ class TestAdminTransaction(
             follow=True,
         )
         self.assertContains(
-            r, "Cannot start a mass upgrade for a disabled organization."
+            r, "Actions cannot modify objects of disabled organizations."
         )
         self.assertEqual(BatchUpgradeOperation.objects.count(), 0)
 
@@ -2197,6 +2219,54 @@ class TestAdminTransaction(
             )
             self.assertFalse(form.is_valid())
             self.assertIn("location", form.errors)
+
+    def test_category_disabled_org_admin_crud(self):
+        self._ensure_administrator_group_permissions()
+        org = self._create_org(name="disabled-org", slug="disabled-org")
+        category = self._create_category(name="disabled-category", organization=org)
+        org.is_active = False
+        org.save(update_fields=["is_active"])
+        self._test_disabled_org_admin_crud(
+            category, change_data={"name": "renamed-category"}
+        )
+
+    def test_category_disabled_org_admin_org_field_excludes_disabled(self):
+        active_org = self._get_org()
+        disabled_org = self._create_org(name="disabled-org", is_active=False)
+        add_url = reverse(f"admin:{self.app_label}_category_add")
+        self._test_disabled_org_admin_org_field_excludes_disabled(
+            add_url, disabled_org, organization=active_org
+        )
+
+    def test_build_disabled_org_admin_crud(self):
+        self._ensure_administrator_group_permissions()
+        org = self._create_org(name="disabled-org", slug="disabled-org")
+        build = self._create_build(organization=org, version="1.0")
+        org.is_active = False
+        org.save(update_fields=["is_active"])
+        self._test_disabled_org_admin_crud(
+            build,
+            change_data={"version": "2.0"},
+            organization=org,
+            unchanged_field="version",
+        )
+
+    def test_build_disabled_org_admin_category_field_excludes_disabled(self):
+        active_org = self._get_org()
+        disabled_org = self._create_org(name="disabled-org", is_active=False)
+        active_category = self._create_category(
+            name="active-org-category", organization=active_org
+        )
+        disabled_category = self._create_category(
+            name="disabled-org-category", organization=disabled_org
+        )
+        request = self.factory.get(reverse(f"admin:{self.app_label}_build_add"))
+        request.user = self._get_admin()
+        build_admin = BuildAdmin(model=Build, admin_site=admin.site)
+        form = build_admin.get_form(request)
+        category_qs = form.base_fields["category"].queryset
+        self.assertIn(active_category, category_qs)
+        self.assertNotIn(disabled_category, category_qs)
 
 
 class TestUpgradeOperationInlineDeletePermission(BaseTestAdmin, TestCase):

--- a/openwisp_firmware_upgrader/tests/test_admin.py
+++ b/openwisp_firmware_upgrader/tests/test_admin.py
@@ -2227,7 +2227,9 @@ class TestAdminTransaction(
         org.is_active = False
         org.save(update_fields=["is_active"])
         self._test_disabled_org_admin_crud(
-            category, change_data={"name": "renamed-category"}
+            category,
+            change_data={"name": "renamed-category"},
+            create_data={"name": "new-category", "organization": str(org.pk)},
         )
 
     def test_category_disabled_org_admin_org_field_excludes_disabled(self):
@@ -2247,6 +2249,7 @@ class TestAdminTransaction(
         self._test_disabled_org_admin_crud(
             build,
             change_data={"version": "2.0"},
+            create_data={"version": "2.0", "category": str(build.category_id)},
             organization=org,
             unchanged_field="version",
         )

--- a/openwisp_firmware_upgrader/tests/test_admin.py
+++ b/openwisp_firmware_upgrader/tests/test_admin.py
@@ -1815,7 +1815,7 @@ class TestAdminTransaction(
                 f"admin:{self.app_label}_batchupgradeoperation_change", args=[batch.pk]
             )
             with self.subTest("Test search + status filter"):
-                with self.assertNumQueries(25 if django.VERSION < (5, 2) else 23):
+                with self.assertNumQueries(26 if django.VERSION < (5, 2) else 24):
                     response = self.client.get(url + "?q=unique-test&status=success")
                 self.assertEqual(response.status_code, 200)
                 self.assertContains(response, "unique-test-device")
@@ -2122,6 +2122,81 @@ class TestAdminTransaction(
             initial_total_upgrade_op_count,
             "Total UpgradeOperation count should remain unchanged",
         )
+
+    def test_device_inlines_readonly_for_disabled_organization(self):
+        active_device_fw = self._create_device_firmware()
+        active_device = active_device_fw.device
+        disabled_org = self._create_org(name="disabled-org")
+        disabled_image = self._create_firmware_image(organization=disabled_org)
+        disabled_device_fw = self._create_device_firmware(image=disabled_image)
+        disabled_device = disabled_device_fw.device
+        disabled_org.is_active = False
+        disabled_org.save(update_fields=["is_active"])
+        deviceadmin = DeviceAdmin(model=Device, admin_site=admin.site)
+        self._test_disabled_org_admin_inline_readonly(
+            deviceadmin,
+            disabled_obj=disabled_device,
+            active_obj=active_device,
+            inline_models=(DeviceFirmwareInline, DeviceUpgradeOperationInline),
+        )
+
+    def test_upgrade_selected_disabled_organization(self):
+        self._login()
+        org = self._get_org()
+        build = self._create_build(organization=org)
+        org.is_active = False
+        org.save(update_fields=["is_active"])
+        r = self.client.post(
+            self.build_list_url,
+            {"action": "upgrade_selected", ACTION_CHECKBOX_NAME: (build.pk,)},
+            follow=True,
+        )
+        self.assertContains(
+            r, "Cannot start a mass upgrade for a disabled organization."
+        )
+        self.assertEqual(BatchUpgradeOperation.objects.count(), 0)
+
+    def test_batch_upgrade_confirmation_form_excludes_disabled_organizations(self):
+        org = self._get_org()
+        disabled_org = self._create_org(name="disabled-org")
+        category = self._create_category(organization=None)
+        build = self._create_build(category=category, version="1.0")
+        group = self._create_device_group(name="Group", organization=org)
+        disabled_group = self._create_device_group(
+            name="Disabled group", organization=disabled_org
+        )
+        location = Location.objects.create(
+            name="Location", address="somewhere", organization=org
+        )
+        disabled_location = Location.objects.create(
+            name="Disabled location", address="somewhere", organization=disabled_org
+        )
+        disabled_org.is_active = False
+        disabled_org.save(update_fields=["is_active"])
+        admin_user = self._get_admin()
+        form = BatchUpgradeConfirmationForm(initial={"build": build}, user=admin_user)
+        group_qs = form.fields["group"].queryset
+        location_qs = form.fields["location"].queryset
+        self.assertIn(group, group_qs)
+        self.assertNotIn(disabled_group, group_qs)
+        self.assertIn(location, location_qs)
+        self.assertNotIn(disabled_location, location_qs)
+
+        with self.subTest("submitting a disabled org group is rejected"):
+            form = BatchUpgradeConfirmationForm(
+                data={"build": build.pk, "group": disabled_group.pk},
+                user=admin_user,
+            )
+            self.assertFalse(form.is_valid())
+            self.assertIn("group", form.errors)
+
+        with self.subTest("submitting a disabled org location is rejected"):
+            form = BatchUpgradeConfirmationForm(
+                data={"build": build.pk, "location": disabled_location.pk},
+                user=admin_user,
+            )
+            self.assertFalse(form.is_valid())
+            self.assertIn("location", form.errors)
 
 
 class TestUpgradeOperationInlineDeletePermission(BaseTestAdmin, TestCase):

--- a/openwisp_firmware_upgrader/tests/test_api.py
+++ b/openwisp_firmware_upgrader/tests/test_api.py
@@ -1595,7 +1595,7 @@ class TestDeviceFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
         self.assertEqual(DeviceFirmware.objects.count(), 0)
         self.assertEqual(UpgradeOperation.objects.count(), 0)
 
-        with self.assertNumQueries(24):
+        with self.assertNumQueries(26):
             data = {"image": image1a.pk}
             # This API view allows the creation
             # of new devicefirmware objects with
@@ -1633,7 +1633,7 @@ class TestDeviceFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
         self.assertEqual(UpgradeOperation.objects.count(), 0)
 
         self.client.force_login(self.administrator)
-        with self.assertNumQueries(23):
+        with self.assertNumQueries(25):
             data = {"image": shared_image.pk}
             r = self.client.put(
                 f"{path}?format=api", data, content_type="application/json"
@@ -1663,7 +1663,7 @@ class TestDeviceFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
         self.assertEqual(DeviceFirmware.objects.count(), 2)
         self.assertEqual(UpgradeOperation.objects.count(), 0)
 
-        with self.assertNumQueries(21):
+        with self.assertNumQueries(23):
             data = {"image": image2a.pk}
             r = self.client.put(
                 f"{url}?format=api", data, content_type="application/json"
@@ -1702,7 +1702,7 @@ class TestDeviceFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
         self.assertEqual(DeviceFirmware.objects.count(), 2)
         self.assertEqual(UpgradeOperation.objects.count(), 0)
 
-        with self.assertNumQueries(21):
+        with self.assertNumQueries(23):
             data = {"image": image2a.pk}
             r = self.client.patch(
                 f"{url}?format=api", data, content_type="application/json"
@@ -1895,19 +1895,11 @@ class TestDeviceFirmwareImageViewsTransaction(
             self.assertEqual(response.status_code, 403)
 
         with self.subTest(
-            "Test superuser cannot delete DeviceFirmwareImage of a deactivated device"
+            "Test superuser can delete DeviceFirmwareImage of a disabled organization"
         ):
-            # Disabling the organization cascades into deactivating its
-            # devices (see openwisp-controller's `organization_disabled`
-            # handler), and a deactivated device blocks all non-GET/HEAD
-            # requests regardless of the requesting user's role.
             response = self.client.delete(url)
-            self.assertEqual(response.status_code, 403)
-            self.assertEqual(
-                response.data["detail"],
-                "Firmware upgrades are not allowed for deactivated devices.",
-            )
-            self.assertEqual(DeviceFirmware.objects.count(), 1)
+            self.assertEqual(response.status_code, 204)
+            self.assertEqual(DeviceFirmware.objects.count(), 0)
 
 
 class TestDeviceUpgradeOperationViews(TestAPIUpgraderMixin, TestCase):

--- a/openwisp_firmware_upgrader/tests/test_api.py
+++ b/openwisp_firmware_upgrader/tests/test_api.py
@@ -22,6 +22,7 @@ from openwisp_firmware_upgrader.tests.base import (
     FirmwareDownloadPermissionTestMixin,
     TestUpgraderMixin,
 )
+from openwisp_users.tests.test_api import TestDisabledOrgApiMixin
 from openwisp_users.tests.utils import TestMultitenantAdminMixin
 from openwisp_utils.tests import AssertNumQueriesSubTestMixin
 
@@ -43,7 +44,10 @@ user_model = get_user_model()
 
 
 class TestAPIUpgraderMixin(
-    AssertNumQueriesSubTestMixin, TestMultitenantAdminMixin, TestUpgraderMixin
+    AssertNumQueriesSubTestMixin,
+    TestMultitenantAdminMixin,
+    TestDisabledOrgApiMixin,
+    TestUpgraderMixin,
 ):
     def setUp(self):
         self.org = self._get_org()
@@ -57,6 +61,18 @@ class TestAPIUpgraderMixin(
         r = self.client.post(url, params)
         self.assertEqual(r.status_code, 200)
         return r.data["token"]
+
+    def _disabled_org_role_user(self, role, organization=None, **kwargs):
+        # setUp() already creates an "administrator" user; reuse it instead of
+        # hitting the username/email unique constraint in the upstream helper.
+        if role == "org_admin" and organization is not None and not kwargs:
+            OrganizationUser.objects.get_or_create(
+                user=self.administrator, organization=organization
+            )
+            return self.administrator
+        return super()._disabled_org_role_user(
+            role, organization=organization, **kwargs
+        )
 
     def _login(self, username="administrator", password="tester"):
         token = self._obtain_auth_token(username, password)
@@ -226,7 +242,7 @@ class TestBuildViews(TestAPIUpgraderMixin, TestCase):
         build = self._create_build()
         serialized = self._serialize_build(build)
         url = reverse("upgrader:api_build_detail", args=[build.pk])
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(4):
             r = self.client.get(url)
         self.assertEqual(r.data, serialized)
 
@@ -239,7 +255,7 @@ class TestBuildViews(TestAPIUpgraderMixin, TestCase):
             "version": "20.04",
             "changelog": "PUT update",
         }
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(9):
             r = self.client.put(url, data, content_type="application/json")
         self.assertEqual(r.data["id"], str(build.pk))
         self.assertEqual(r.data["category"], build.category.pk)
@@ -251,7 +267,7 @@ class TestBuildViews(TestAPIUpgraderMixin, TestCase):
         url = reverse("upgrader:api_build_detail", args=[build.pk])
         data = dict(changelog="PATCH update")
         expected_queries = (
-            8 if parse_version(REST_FRAMEWORK_VERSION) >= parse_version("3.15") else 9
+            7 if parse_version(REST_FRAMEWORK_VERSION) >= parse_version("3.15") else 8
         )
         with self.assertNumQueries(expected_queries):
             r = self.client.patch(url, data, content_type="application/json")
@@ -267,6 +283,32 @@ class TestBuildViews(TestAPIUpgraderMixin, TestCase):
         r = self.client.delete(url)
         self.assertEqual(r.status_code, 204)
         self.assertEqual(Build.objects.count(), 0)
+
+    def test_build_disabled_organization_crud(self):
+        org = self._get_org()
+        category = self._create_category(organization=org)
+        build = self._create_build(category=category, version="1.0")
+        org.is_active = False
+        org.save(update_fields=["is_active"])
+        self._test_disabled_org_api_crud(
+            build,
+            detail_url=reverse("upgrader:api_build_detail", args=[build.pk]),
+            list_url=reverse("upgrader:api_build_list"),
+            create_payload={"category": category.pk, "version": "2.0"},
+            update_payload={"changelog": "changed"},
+            unchanged_field="version",
+            organization=org,
+            # Build has no "organization" field: the disabled org is reached
+            # through "category", which _filter_related_field filters out
+            # without customizing the DRF "does_not_exist" error message.
+            superuser_expected={
+                "create": {
+                    "status": 400,
+                    "error_field": "category",
+                    "error_contains": "does not exist",
+                }
+            },
+        )
 
     def test_shared_build(self):
         self._create_admin(username="admin", password="tester")
@@ -326,7 +368,7 @@ class TestBuildViews(TestAPIUpgraderMixin, TestCase):
         self.assertEqual(BatchUpgradeOperation.objects.count(), 0)
         with self.subTest("Existing build"):
             url = reverse("upgrader:api_build_batch_upgrade", args=[build.pk])
-            with self.assertNumQueries(10):
+            with self.assertNumQueries(9):
                 r = self.client.post(url)
             self.assertEqual(BatchUpgradeOperation.objects.count(), 1)
             batch = BatchUpgradeOperation.objects.first()
@@ -344,7 +386,7 @@ class TestBuildViews(TestAPIUpgraderMixin, TestCase):
         self.assertEqual(BatchUpgradeOperation.objects.count(), 0)
 
         url = reverse("upgrader:api_build_batch_upgrade", args=[env["build2"].pk])
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(9):
             r = self.client.get(url)
         self.assertEqual(r.status_code, 200)
         device_fw_list = [
@@ -379,6 +421,32 @@ class TestBuildViews(TestAPIUpgraderMixin, TestCase):
         self.assertIn(str(env["device_fw2"].pk), r.data["device_firmwares"])
         self.assertNotIn(str(firmwareless_device.pk), r.data["devices"])
         self.assertIn(str(active_firmwareless_device.pk), r.data["devices"])
+
+    def test_build_batch_upgrade_disabled_organization(self):
+        env = self._create_upgrade_env()
+        org = env["category"].organization
+        org.is_active = False
+        org.save(update_fields=["is_active"])
+        url = reverse("upgrader:api_build_batch_upgrade", args=[env["build2"].pk])
+
+        with self.subTest("Test org manager cannot mass upgrade disabled organization"):
+            r = self.client.post(url)
+            self.assertEqual(r.status_code, 403)
+
+        with self.subTest("Test superuser cannot mass upgrade disabled organization"):
+            superuser = self._create_operator(
+                username="superuser", email="superuser@test.com", is_superuser=True
+            )
+            self._login(username=superuser.username)
+            r = self.client.post(url)
+            self.assertEqual(r.status_code, 403)
+            self.assertIn(
+                "This object belongs to a disabled organization:"
+                " it can be viewed or deleted, but not modified.",
+                r.data["detail"],
+            )
+
+        self.assertEqual(BatchUpgradeOperation.objects.count(), 0)
 
     def test_api_shared_build_batch_upgrade(self):
         shared_image = self._create_firmware_image(organization=None)
@@ -855,7 +923,7 @@ class TestCategoryViews(TestAPIUpgraderMixin, TestCase):
         category = self._get_category()
         serialized = self._serialize_category(category)
         url = reverse("upgrader:api_category_detail", args=[category.pk])
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(4):
             r = self.client.get(url)
         self.assertEqual(r.data, serialized)
 
@@ -866,7 +934,7 @@ class TestCategoryViews(TestAPIUpgraderMixin, TestCase):
             "name": "New name",
             "organization": category.organization.pk,
         }
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(9):
             r = self.client.put(url, data, content_type="application/json")
         self.assertEqual(r.data["id"], str(category.pk))
         self.assertEqual(r.data["name"], "New name")
@@ -876,7 +944,7 @@ class TestCategoryViews(TestAPIUpgraderMixin, TestCase):
         category = self._get_category()
         url = reverse("upgrader:api_category_detail", args=[category.pk])
         data = dict(name="New name")
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(8):
             r = self.client.patch(url, data, content_type="application/json")
         self.assertEqual(r.data["id"], str(category.pk))
         self.assertEqual(r.data["name"], "New name")
@@ -889,6 +957,21 @@ class TestCategoryViews(TestAPIUpgraderMixin, TestCase):
         r = self.client.delete(url)
         self.assertEqual(r.status_code, 204)
         self.assertEqual(Category.objects.count(), 0)
+
+    def test_category_disabled_organization_crud(self):
+        org = self._get_org()
+        category = self._create_category(organization=org)
+        org.is_active = False
+        org.save(update_fields=["is_active"])
+        self._test_disabled_org_api_crud(
+            category,
+            detail_url=reverse("upgrader:api_category_detail", args=[category.pk]),
+            list_url=reverse("upgrader:api_category_list"),
+            create_payload={"name": "new-category", "organization": org.pk},
+            update_payload={"name": "changed"},
+            unchanged_field="name",
+            organization=org,
+        )
 
 
 class TestBatchUpgradeOperationViews(TestAPIUpgraderMixin, TestCase):
@@ -1039,7 +1122,7 @@ class TestBatchUpgradeOperationViews(TestAPIUpgraderMixin, TestCase):
         operation = BatchUpgradeOperation.objects.get(build=env["build2"])
         serialized = self._serialize_upgrade_env(operation, action="detail")
         url = reverse("upgrader:api_batchupgradeoperation_detail", args=[operation.pk])
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(6):
             r = self.client.get(url)
         self.assertEqual(r.data, serialized)
 
@@ -1083,7 +1166,7 @@ class TestFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
         image = self._create_firmware_image()
         self._create_firmware_image(type=self.TPLINK_4300_IL_IMAGE)
         url = reverse("upgrader:api_firmware_list", args=[image.build.pk])
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(6):
             r = self.client.get(url)
 
         # Verify file URLs point to API endpoint
@@ -1114,12 +1197,12 @@ class TestFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
         image2 = self._create_firmware_image(type=self.TPLINK_4300_IL_IMAGE)
         url = reverse("upgrader:api_firmware_list", args=[image.build.pk])
         filter_params = dict(type=self.TPLINK_4300_IMAGE)
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(6):
             r = self.client.get(url, filter_params)
         self.assertEqual(r.data["results"], [self._serialize_image(image)])
         url = reverse("upgrader:api_firmware_list", args=[image.build.pk])
         filter_params = dict(type=self.TPLINK_4300_IL_IMAGE)
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(6):
             r = self.client.get(url, filter_params)
         self.assertEqual(r.data["results"], [self._serialize_image(image2)])
 
@@ -1136,14 +1219,14 @@ class TestFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
         url = reverse("upgrader:api_firmware_list", args=[image.build.pk])
         self._login("operator", "tester")
         serialized_list = [self._serialize_image(image)]
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(6):
             r = self.client.get(url)
         self.assertEqual(r.data["results"], serialized_list)
 
         url = reverse("upgrader:api_firmware_list", args=[image2.build.pk])
         self._login("operator2", "tester")
         serialized_list = [self._serialize_image(image2)]
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(6):
             r = self.client.get(url)
         self.assertEqual(r.data["results"], serialized_list)
 
@@ -1165,7 +1248,7 @@ class TestFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
             self._serialize_image(image),
         ]
 
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(4):
             r = self.client.get(url)
         self.assertEqual(r.data["results"], serialized_list)
 
@@ -1173,7 +1256,7 @@ class TestFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
 
         data_filter = {"org": "New org"}
         serialized_list = [self._serialize_image(image2)]
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(4):
             r = self.client.get(url, data_filter)
         self.assertEqual(r.data["results"], serialized_list)
 
@@ -1210,7 +1293,7 @@ class TestFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
         image = self._create_firmware_image()
         serialized = self._serialize_image(image)
         url = reverse("upgrader:api_firmware_detail", args=[image.build.pk, image.pk])
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(5):
             r = self.client.get(url)
         self.assertEqual(r.data, serialized)
 
@@ -1218,10 +1301,27 @@ class TestFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
         image = self._create_firmware_image()
         self.assertEqual(FirmwareImage.objects.count(), 1)
         url = reverse("upgrader:api_firmware_detail", args=[image.build.pk, image.pk])
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(8):
             r = self.client.delete(url)
         self.assertEqual(r.status_code, 204)
         self.assertEqual(FirmwareImage.objects.count(), 0)
+
+    def test_firmware_disabled_organization_crud(self):
+        org = self._get_org()
+        image = self._create_firmware_image(organization=org)
+        org.is_active = False
+        org.save(update_fields=["is_active"])
+        self._test_disabled_org_api_crud(
+            image,
+            detail_url=reverse(
+                "upgrader:api_firmware_detail", args=[image.build.pk, image.pk]
+            ),
+            list_url=reverse("upgrader:api_firmware_list", args=[image.build.pk]),
+            # FirmwareImageDetailView is retrieve/destroy only, and creation
+            # requires a multipart file upload the JSON-only helper cannot do.
+            operations=("list", "retrieve", "delete"),
+            organization=org,
+        )
 
     def test_firmware_download(self):
         image = self._create_firmware_image()
@@ -1335,7 +1435,7 @@ class TestDeviceFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
 
         with self.subTest("Test device and image model validation"):
             url = reverse("upgrader:api_devicefirmware_detail", args=[device1.pk])
-            with self.assertNumQueries(13):
+            with self.assertNumQueries(12):
                 # Try to make a request when the
                 # device model does not match the image model
                 data = {"image": image1a.pk}
@@ -1346,7 +1446,7 @@ class TestDeviceFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
 
         with self.subTest("Test image pk validation"):
             url = reverse("upgrader:api_devicefirmware_detail", args=[device2.pk])
-            with self.assertNumQueries(8):
+            with self.assertNumQueries(7):
                 # image with different "type"
                 data = {"image": image1a.pk}
                 r = self.client.put(url, data, content_type="application/json")
@@ -1399,6 +1499,96 @@ class TestDeviceFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
         self.assertEqual(DeviceFirmware.objects.count(), 0)
         self.assertEqual(UpgradeOperation.objects.count(), 0)
 
+    def test_disabled_organization_device_firmware_put_as_create(self):
+        env = self._create_upgrade_env(device_firmware=False)
+        url = reverse("upgrader:api_devicefirmware_detail", args=[env["d1"].pk])
+        org = env["category"].organization
+        org.is_active = False
+        org.save(update_fields=["is_active"])
+
+        with self.subTest("Test org manager cannot create DeviceFirmwareImage"):
+            response = self.client.put(
+                url,
+                data={"image": env["image1a"].pk},
+                content_type="application/json",
+            )
+            self.assertEqual(response.status_code, 403)
+            self.assertEqual(
+                response.data["detail"],
+                "User is not a manager of the organization to which the "
+                "requested resource belongs.",
+            )
+
+        with self.subTest("Test superuser cannot create DeviceFirmwareImage"):
+            superuser = self._create_operator(
+                username="superuser", email="superuser@test.com", is_superuser=True
+            )
+            self._login(username=superuser.username)
+            response = self.client.put(
+                url,
+                data={"image": env["image1a"].pk},
+                content_type="application/json",
+            )
+            self.assertEqual(response.status_code, 403)
+            self.assertEqual(
+                response.data["detail"],
+                "Firmware upgrades are not allowed for disabled organizations.",
+            )
+
+        self.assertEqual(DeviceFirmware.objects.count(), 0)
+        self.assertEqual(UpgradeOperation.objects.count(), 0)
+
+    def test_disabled_organization_device_firmware(self):
+        device_fw = self._create_device_firmware()
+        org = device_fw.device.organization
+        org.is_active = False
+        org.save(update_fields=["is_active"])
+        url = reverse("upgrader:api_devicefirmware_detail", args=[device_fw.device.pk])
+
+        with self.subTest("Test org manager cannot retrieve DeviceFirmwareImage"):
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 403)
+
+        with self.subTest("Test org manager cannot update DeviceFirmwareImage"):
+            response = self.client.put(
+                url,
+                data={"image": device_fw.image.pk},
+                content_type="application/json",
+            )
+            self.assertEqual(response.status_code, 403)
+            self.assertEqual(
+                response.data["detail"],
+                "User is not a manager of the organization to which the "
+                "requested resource belongs.",
+            )
+
+        with self.subTest("Test org manager cannot delete DeviceFirmwareImage"):
+            response = self.client.delete(url)
+            self.assertEqual(response.status_code, 403)
+            self.assertEqual(DeviceFirmware.objects.count(), 1)
+
+        superuser = self._create_operator(
+            username="superuser", email="superuser@test.com", is_superuser=True
+        )
+        self._login(username=superuser.username)
+
+        with self.subTest("Test superuser can retrieve DeviceFirmwareImage"):
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 200)
+
+        with self.subTest("Test superuser cannot update DeviceFirmwareImage"):
+            response = self.client.put(
+                url,
+                data={"image": device_fw.image.pk},
+                content_type="application/json",
+            )
+            self.assertEqual(response.status_code, 403)
+
+        with self.subTest("Test superuser can delete DeviceFirmwareImage"):
+            response = self.client.delete(url)
+            self.assertEqual(response.status_code, 204)
+            self.assertEqual(DeviceFirmware.objects.count(), 0)
+
     def test_device_firmware_detail_delete(self):
         device_fw = self._create_device_firmware()
         self.assertEqual(DeviceFirmware.objects.count(), 1)
@@ -1425,7 +1615,7 @@ class TestDeviceFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
             url = reverse(
                 "upgrader:api_devicefirmware_detail", args=[device_fw1.device.pk]
             )
-            with self.assertNumQueries(8):
+            with self.assertNumQueries(7):
                 r = self.client.get(url, {"format": "api"})
             self.assertEqual(r.status_code, 200)
             serializer_detail = self._serialize_device_firmware(device_fw1)
@@ -1473,7 +1663,7 @@ class TestDeviceFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
         self.assertEqual(DeviceFirmware.objects.count(), 0)
         self.assertEqual(UpgradeOperation.objects.count(), 0)
 
-        with self.assertNumQueries(25):
+        with self.assertNumQueries(24):
             data = {"image": image1a.pk}
             # This API view allows the creation
             # of new devicefirmware objects with
@@ -1511,7 +1701,7 @@ class TestDeviceFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
         self.assertEqual(UpgradeOperation.objects.count(), 0)
 
         self.client.force_login(self.administrator)
-        with self.assertNumQueries(24):
+        with self.assertNumQueries(23):
             data = {"image": shared_image.pk}
             r = self.client.put(
                 f"{path}?format=api", data, content_type="application/json"
@@ -1541,7 +1731,7 @@ class TestDeviceFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
         self.assertEqual(DeviceFirmware.objects.count(), 2)
         self.assertEqual(UpgradeOperation.objects.count(), 0)
 
-        with self.assertNumQueries(22):
+        with self.assertNumQueries(21):
             data = {"image": image2a.pk}
             r = self.client.put(
                 f"{url}?format=api", data, content_type="application/json"
@@ -1580,7 +1770,7 @@ class TestDeviceFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
         self.assertEqual(DeviceFirmware.objects.count(), 2)
         self.assertEqual(UpgradeOperation.objects.count(), 0)
 
-        with self.assertNumQueries(22):
+        with self.assertNumQueries(21):
             data = {"image": image2a.pk}
             r = self.client.patch(
                 f"{url}?format=api", data, content_type="application/json"
@@ -1615,7 +1805,7 @@ class TestDeviceFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
         with self.subTest("Test device firmware detail org manager"):
             self._login("org1_manager", "tester")
             url = reverse("upgrader:api_devicefirmware_detail", args=[d1.pk])
-            with self.assertNumQueries(7):
+            with self.assertNumQueries(6):
                 r = self.client.get(url, {"format": "api"})
             self.assertEqual(r.status_code, 200)
             serializer_detail = self._serialize_device_firmware(device_fw1)
@@ -1960,7 +2150,7 @@ class TestUpgradeOperationViews(TestAPIUpgraderMixin, TestCase):
 
         with self.subTest("Test when upgrade operations exist"):
             url = reverse("upgrader:api_upgradeoperation_detail", args=[uo1.pk])
-            with self.assertNumQueries(5):
+            with self.assertNumQueries(4):
                 r = self.client.get(url)
             self.assertEqual(r.status_code, 200)
             serializer_list = self._serialize_upgrade_operation(uo1)
@@ -2017,7 +2207,7 @@ class TestUpgradeOperationViews(TestAPIUpgraderMixin, TestCase):
         with self.subTest("Test upgrade operation detail org manager"):
             self._login("org1_manager", "tester")
             url = reverse("upgrader:api_upgradeoperation_detail", args=[uo1.pk])
-            with self.assertNumQueries(5):
+            with self.assertNumQueries(4):
                 r = self.client.get(url)
             self.assertEqual(r.status_code, 200)
             serializer_detail = self._serialize_upgrade_operation(uo1)
@@ -2158,6 +2348,39 @@ class TestApiMisc(TestAPIUpgraderMixin, TestCase):
         response = self.client.post(url)
         self.assertEqual(response.status_code, 404)
         self.assertIn("not found", response.data["error"])
+
+    def test_upgrade_operation_cancel_allowed_for_deactivated_device(self):
+        env = self._create_upgrade_env(upgrade_operation=True, organization=self.org)
+        device = env["d1"]
+        operation = UpgradeOperation.objects.create(
+            device=device, image=env["image2a"], status="in-progress", progress=30
+        )
+        device.deactivate()
+        url = reverse(
+            "upgrader:api_upgradeoperation_cancel", kwargs={"pk": operation.pk}
+        )
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 200)
+        operation.refresh_from_db()
+        self.assertEqual(operation.status, "cancelled")
+
+    def test_upgrade_operation_cancel_allowed_for_disabled_org_device(self):
+        env = self._create_upgrade_env(upgrade_operation=True, organization=self.org)
+        device = env["d2"]
+        operation = UpgradeOperation.objects.create(
+            device=device, image=env["image2b"], status="in-progress", progress=30
+        )
+        org = device.organization
+        org.is_active = False
+        org.save(update_fields=["is_active"])
+        self._login(self._get_admin().username)
+        url = reverse(
+            "upgrader:api_upgradeoperation_cancel", kwargs={"pk": operation.pk}
+        )
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 200)
+        operation.refresh_from_db()
+        self.assertEqual(operation.status, "cancelled")
 
 
 class TestFirmwareDownloadPermissions(

--- a/openwisp_firmware_upgrader/tests/test_api.py
+++ b/openwisp_firmware_upgrader/tests/test_api.py
@@ -67,7 +67,9 @@ class TestAPIUpgraderMixin(
         # hitting the username/email unique constraint in the upstream helper.
         if role == "org_admin" and organization is not None and not kwargs:
             OrganizationUser.objects.get_or_create(
-                user=self.administrator, organization=organization
+                user=self.administrator,
+                organization=organization,
+                defaults={"is_admin": True},
             )
             return self.administrator
         return super()._disabled_org_role_user(

--- a/openwisp_firmware_upgrader/tests/test_api.py
+++ b/openwisp_firmware_upgrader/tests/test_api.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 import swapper
 from django.contrib.auth import get_user_model
-from django.test import Client, TestCase
+from django.test import Client, TestCase, TransactionTestCase
 from django.urls import reverse
 from packaging.version import parse as parse_version
 from rest_framework import VERSION as REST_FRAMEWORK_VERSION
@@ -285,32 +285,6 @@ class TestBuildViews(TestAPIUpgraderMixin, TestCase):
         r = self.client.delete(url)
         self.assertEqual(r.status_code, 204)
         self.assertEqual(Build.objects.count(), 0)
-
-    def test_build_disabled_organization_crud(self):
-        org = self._get_org()
-        category = self._create_category(organization=org)
-        build = self._create_build(category=category, version="1.0")
-        org.is_active = False
-        org.save(update_fields=["is_active"])
-        self._test_disabled_org_api_crud(
-            build,
-            detail_url=reverse("upgrader:api_build_detail", args=[build.pk]),
-            list_url=reverse("upgrader:api_build_list"),
-            create_payload={"category": category.pk, "version": "2.0"},
-            update_payload={"changelog": "changed"},
-            unchanged_field="version",
-            organization=org,
-            # Build has no "organization" field: the disabled org is reached
-            # through "category", which _filter_related_field filters out
-            # without customizing the DRF "does_not_exist" error message.
-            superuser_expected={
-                "create": {
-                    "status": 400,
-                    "error_field": "category",
-                    "error_contains": "does not exist",
-                }
-            },
-        )
 
     def test_shared_build(self):
         self._create_admin(username="admin", password="tester")
@@ -765,6 +739,38 @@ class TestBuildViews(TestAPIUpgraderMixin, TestCase):
             self.assertEqual(len(r.data["devices"]), 0)
 
 
+class TestBuildViewsTransaction(TestAPIUpgraderMixin, TransactionTestCase):
+    def setUp(self):
+        self._ensure_default_group_permissions()
+        super().setUp()
+
+    def test_build_disabled_organization_crud(self):
+        org = self._get_org()
+        category = self._create_category(organization=org)
+        build = self._create_build(category=category, version="1.0")
+        org.is_active = False
+        org.save(update_fields=["is_active"])
+        self._test_disabled_org_api_crud(
+            build,
+            detail_url=reverse("upgrader:api_build_detail", args=[build.pk]),
+            list_url=reverse("upgrader:api_build_list"),
+            create_payload={"category": category.pk, "version": "2.0"},
+            update_payload={"changelog": "changed"},
+            unchanged_field="version",
+            organization=org,
+            # Build has no "organization" field: the disabled org is reached
+            # through "category", which _filter_related_field filters out
+            # without customizing the DRF "does_not_exist" error message.
+            superuser_expected={
+                "create": {
+                    "status": 400,
+                    "error_field": "category",
+                    "error_contains": "does not exist",
+                }
+            },
+        )
+
+
 class TestCategoryViews(TestAPIUpgraderMixin, TestCase):
     def _serialize_category(self, category):
         serializer = CategorySerializer()
@@ -959,6 +965,12 @@ class TestCategoryViews(TestAPIUpgraderMixin, TestCase):
         r = self.client.delete(url)
         self.assertEqual(r.status_code, 204)
         self.assertEqual(Category.objects.count(), 0)
+
+
+class TestCategoryViewsTransaction(TestAPIUpgraderMixin, TransactionTestCase):
+    def setUp(self):
+        self._ensure_default_group_permissions()
+        super().setUp()
 
     def test_category_disabled_organization_crud(self):
         org = self._get_org()
@@ -1303,27 +1315,12 @@ class TestFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
         image = self._create_firmware_image()
         self.assertEqual(FirmwareImage.objects.count(), 1)
         url = reverse("upgrader:api_firmware_detail", args=[image.build.pk, image.pk])
-        with self.assertNumQueries(8):
+        # +1 query: `_abort_related_upgrade_operations` looks up in-progress
+        # operations referencing the image before it is deleted.
+        with self.assertNumQueries(9):
             r = self.client.delete(url)
         self.assertEqual(r.status_code, 204)
         self.assertEqual(FirmwareImage.objects.count(), 0)
-
-    def test_firmware_disabled_organization_crud(self):
-        org = self._get_org()
-        image = self._create_firmware_image(organization=org)
-        org.is_active = False
-        org.save(update_fields=["is_active"])
-        self._test_disabled_org_api_crud(
-            image,
-            detail_url=reverse(
-                "upgrader:api_firmware_detail", args=[image.build.pk, image.pk]
-            ),
-            list_url=reverse("upgrader:api_firmware_list", args=[image.build.pk]),
-            # FirmwareImageDetailView is retrieve/destroy only, and creation
-            # requires a multipart file upload the JSON-only helper cannot do.
-            operations=("list", "retrieve", "delete"),
-            organization=org,
-        )
 
     def test_firmware_download(self):
         image = self._create_firmware_image()
@@ -1358,6 +1355,29 @@ class TestFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
         data = dict(type=self.TPLINK_4300_IL_IMAGE)
         r = self.client.patch(url, data, content_type="application/json")
         self.assertEqual(r.status_code, 405)
+
+
+class TestFirmwareImageViewsTransaction(TestAPIUpgraderMixin, TransactionTestCase):
+    def setUp(self):
+        self._ensure_default_group_permissions()
+        super().setUp()
+
+    def test_firmware_disabled_organization_crud(self):
+        org = self._get_org()
+        image = self._create_firmware_image(organization=org)
+        org.is_active = False
+        org.save(update_fields=["is_active"])
+        self._test_disabled_org_api_crud(
+            image,
+            detail_url=reverse(
+                "upgrader:api_firmware_detail", args=[image.build.pk, image.pk]
+            ),
+            list_url=reverse("upgrader:api_firmware_list", args=[image.build.pk]),
+            # FirmwareImageDetailView is retrieve/destroy only, and creation
+            # requires a multipart file upload the JSON-only helper cannot do.
+            operations=("list", "retrieve", "delete"),
+            organization=org,
+        )
 
 
 class TestDeviceFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
@@ -1500,96 +1520,6 @@ class TestDeviceFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
         )
         self.assertEqual(DeviceFirmware.objects.count(), 0)
         self.assertEqual(UpgradeOperation.objects.count(), 0)
-
-    def test_disabled_organization_device_firmware_put_as_create(self):
-        env = self._create_upgrade_env(device_firmware=False)
-        url = reverse("upgrader:api_devicefirmware_detail", args=[env["d1"].pk])
-        org = env["category"].organization
-        org.is_active = False
-        org.save(update_fields=["is_active"])
-
-        with self.subTest("Test org manager cannot create DeviceFirmwareImage"):
-            response = self.client.put(
-                url,
-                data={"image": env["image1a"].pk},
-                content_type="application/json",
-            )
-            self.assertEqual(response.status_code, 403)
-            self.assertEqual(
-                response.data["detail"],
-                "User is not a manager of the organization to which the "
-                "requested resource belongs.",
-            )
-
-        with self.subTest("Test superuser cannot create DeviceFirmwareImage"):
-            superuser = self._create_operator(
-                username="superuser", email="superuser@test.com", is_superuser=True
-            )
-            self._login(username=superuser.username)
-            response = self.client.put(
-                url,
-                data={"image": env["image1a"].pk},
-                content_type="application/json",
-            )
-            self.assertEqual(response.status_code, 403)
-            self.assertEqual(
-                response.data["detail"],
-                "Firmware upgrades are not allowed for disabled organizations.",
-            )
-
-        self.assertEqual(DeviceFirmware.objects.count(), 0)
-        self.assertEqual(UpgradeOperation.objects.count(), 0)
-
-    def test_disabled_organization_device_firmware(self):
-        device_fw = self._create_device_firmware()
-        org = device_fw.device.organization
-        org.is_active = False
-        org.save(update_fields=["is_active"])
-        url = reverse("upgrader:api_devicefirmware_detail", args=[device_fw.device.pk])
-
-        with self.subTest("Test org manager cannot retrieve DeviceFirmwareImage"):
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, 403)
-
-        with self.subTest("Test org manager cannot update DeviceFirmwareImage"):
-            response = self.client.put(
-                url,
-                data={"image": device_fw.image.pk},
-                content_type="application/json",
-            )
-            self.assertEqual(response.status_code, 403)
-            self.assertEqual(
-                response.data["detail"],
-                "User is not a manager of the organization to which the "
-                "requested resource belongs.",
-            )
-
-        with self.subTest("Test org manager cannot delete DeviceFirmwareImage"):
-            response = self.client.delete(url)
-            self.assertEqual(response.status_code, 403)
-            self.assertEqual(DeviceFirmware.objects.count(), 1)
-
-        superuser = self._create_operator(
-            username="superuser", email="superuser@test.com", is_superuser=True
-        )
-        self._login(username=superuser.username)
-
-        with self.subTest("Test superuser can retrieve DeviceFirmwareImage"):
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, 200)
-
-        with self.subTest("Test superuser cannot update DeviceFirmwareImage"):
-            response = self.client.put(
-                url,
-                data={"image": device_fw.image.pk},
-                content_type="application/json",
-            )
-            self.assertEqual(response.status_code, 403)
-
-        with self.subTest("Test superuser can delete DeviceFirmwareImage"):
-            response = self.client.delete(url)
-            self.assertEqual(response.status_code, 204)
-            self.assertEqual(DeviceFirmware.objects.count(), 0)
 
     def test_device_firmware_detail_delete(self):
         device_fw = self._create_device_firmware()
@@ -1870,6 +1800,114 @@ class TestDeviceFirmwareImageViews(TestAPIUpgraderMixin, TestCase):
             "Firmware upgrades are not allowed for deactivated devices.",
             str(serializer.errors),
         )
+
+
+class TestDeviceFirmwareImageViewsTransaction(
+    TestAPIUpgraderMixin, TransactionTestCase
+):
+    def setUp(self):
+        self._ensure_default_group_permissions()
+        super().setUp()
+
+    def test_disabled_organization_device_firmware_put_as_create(self):
+        env = self._create_upgrade_env(device_firmware=False)
+        url = reverse("upgrader:api_devicefirmware_detail", args=[env["d1"].pk])
+        org = env["category"].organization
+        org.is_active = False
+        org.save(update_fields=["is_active"])
+
+        with self.subTest("Test org manager cannot create DeviceFirmwareImage"):
+            response = self.client.put(
+                url,
+                data={"image": env["image1a"].pk},
+                content_type="application/json",
+            )
+            self.assertEqual(response.status_code, 403)
+            self.assertEqual(
+                response.data["detail"],
+                "User is not a manager of the organization to which the "
+                "requested resource belongs.",
+            )
+
+        with self.subTest("Test superuser cannot create DeviceFirmwareImage"):
+            superuser = self._create_operator(
+                username="superuser", email="superuser@test.com", is_superuser=True
+            )
+            self._login(username=superuser.username)
+            response = self.client.put(
+                url,
+                data={"image": env["image1a"].pk},
+                content_type="application/json",
+            )
+            self.assertEqual(response.status_code, 403)
+            self.assertEqual(
+                response.data["detail"],
+                "Firmware upgrades are not allowed for deactivated devices.",
+            )
+
+        self.assertEqual(DeviceFirmware.objects.count(), 0)
+        self.assertEqual(UpgradeOperation.objects.count(), 0)
+
+    def test_disabled_organization_device_firmware(self):
+        device_fw = self._create_device_firmware()
+        org = device_fw.device.organization
+        org.is_active = False
+        org.save(update_fields=["is_active"])
+        url = reverse("upgrader:api_devicefirmware_detail", args=[device_fw.device.pk])
+
+        with self.subTest("Test org manager cannot retrieve DeviceFirmwareImage"):
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 403)
+
+        with self.subTest("Test org manager cannot update DeviceFirmwareImage"):
+            response = self.client.put(
+                url,
+                data={"image": device_fw.image.pk},
+                content_type="application/json",
+            )
+            self.assertEqual(response.status_code, 403)
+            self.assertEqual(
+                response.data["detail"],
+                "User is not a manager of the organization to which the "
+                "requested resource belongs.",
+            )
+
+        with self.subTest("Test org manager cannot delete DeviceFirmwareImage"):
+            response = self.client.delete(url)
+            self.assertEqual(response.status_code, 403)
+            self.assertEqual(DeviceFirmware.objects.count(), 1)
+
+        superuser = self._create_operator(
+            username="superuser", email="superuser@test.com", is_superuser=True
+        )
+        self._login(username=superuser.username)
+
+        with self.subTest("Test superuser can retrieve DeviceFirmwareImage"):
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 200)
+
+        with self.subTest("Test superuser cannot update DeviceFirmwareImage"):
+            response = self.client.put(
+                url,
+                data={"image": device_fw.image.pk},
+                content_type="application/json",
+            )
+            self.assertEqual(response.status_code, 403)
+
+        with self.subTest(
+            "Test superuser cannot delete DeviceFirmwareImage of a deactivated device"
+        ):
+            # Disabling the organization cascades into deactivating its
+            # devices (see openwisp-controller's `organization_disabled`
+            # handler), and a deactivated device blocks all non-GET/HEAD
+            # requests regardless of the requesting user's role.
+            response = self.client.delete(url)
+            self.assertEqual(response.status_code, 403)
+            self.assertEqual(
+                response.data["detail"],
+                "Firmware upgrades are not allowed for deactivated devices.",
+            )
+            self.assertEqual(DeviceFirmware.objects.count(), 1)
 
 
 class TestDeviceUpgradeOperationViews(TestAPIUpgraderMixin, TestCase):

--- a/openwisp_firmware_upgrader/tests/test_api.py
+++ b/openwisp_firmware_upgrader/tests/test_api.py
@@ -1894,8 +1894,10 @@ class TestDeviceFirmwareImageViewsTransaction(
             )
             self.assertEqual(response.status_code, 403)
 
+        device_fw.device.deactivate()
+
         with self.subTest(
-            "Test superuser can delete DeviceFirmwareImage of a disabled organization"
+            "Test superuser can delete DeviceFirmwareImage of a disabled organization and deactivated device"
         ):
             response = self.client.delete(url)
             self.assertEqual(response.status_code, 204)

--- a/openwisp_firmware_upgrader/tests/test_models.py
+++ b/openwisp_firmware_upgrader/tests/test_models.py
@@ -727,6 +727,22 @@ class TestModelsTransaction(TestUpgraderMixin, TransactionTestCase):
             self.assertEqual(batch.build, env["build2"])
             self.assertEqual(batch.status, "success")
 
+    @mock.patch("openwisp_firmware_upgrader.base.models.upgrade_firmware.delay")
+    def test_upgrade_related_devices_query_count(self, _mocked_delay):
+        env = self._create_upgrade_env()
+        batch = BatchUpgradeOperation.objects.create(build=env["build2"])
+        with self.assertNumQueries(43):
+            batch.upgrade(firmwareless=False)
+        self.assertEqual(batch.upgradeoperation_set.count(), 2)
+
+    @mock.patch("openwisp_firmware_upgrader.base.models.upgrade_firmware.delay")
+    def test_upgrade_firmwareless_devices_query_count(self, _mocked_delay):
+        env = self._create_upgrade_env(device_firmware=False)
+        batch = BatchUpgradeOperation.objects.create(build=env["build2"])
+        with self.assertNumQueries(43):
+            batch.upgrade(firmwareless=True)
+        self.assertEqual(batch.upgradeoperation_set.count(), 2)
+
     @mock.patch(_mock_updrade, return_value=True)
     def test_upgrade_firmwareless_devices(self, *args):
         with mock.patch(self._mock_connect, return_value=True):
@@ -1451,9 +1467,12 @@ class TestModelsTransaction(TestUpgraderMixin, TransactionTestCase):
 
         with self.subTest("DeviceFirmware.save(upgrade=True) raises and creates no op"):
             uo_count = UpgradeOperation.objects.count()
-            device_fw.installed = False
-            with self.assertRaises(ValidationError):
-                device_fw.full_clean()
+            previous_image_id = device_fw.image_id
+            previous_installed = device_fw.installed
+            build = self._create_build(
+                category=device_fw.image.build.category, version="0.2"
+            )
+            device_fw.image = self._create_firmware_image(build=build)
             with self.assertRaises(ValidationError) as cm:
                 device_fw.save(upgrade=True)
             self.assertIn(
@@ -1461,3 +1480,6 @@ class TestModelsTransaction(TestUpgraderMixin, TransactionTestCase):
                 str(cm.exception),
             )
             self.assertEqual(UpgradeOperation.objects.count(), uo_count)
+            device_fw.refresh_from_db()
+            self.assertEqual(device_fw.image_id, previous_image_id)
+            self.assertEqual(device_fw.installed, previous_installed)

--- a/openwisp_firmware_upgrader/tests/test_models.py
+++ b/openwisp_firmware_upgrader/tests/test_models.py
@@ -355,6 +355,23 @@ class TestModels(TestUpgraderMixin, TestCase):
         self.assertEqual(operation.status, "aborted")
         self.assertIn("deactivated", operation.log)
 
+    def test_upgrade_operation_aborts_when_organization_disabled_before_worker_runs(
+        self,
+    ):
+        device_fw = self._create_device_firmware()
+        operation = UpgradeOperation(device=device_fw.device, image=device_fw.image)
+        operation.full_clean()
+        operation.save()
+        org = device_fw.device.organization
+        org.is_active = False
+        org.save(update_fields=["is_active"])
+        with mock.patch.object(DeviceConnection, "get_working_connection") as mocked:
+            operation.upgrade()
+        mocked.assert_not_called()
+        operation.refresh_from_db()
+        self.assertEqual(operation.status, "aborted")
+        self.assertIn("disabled", operation.log)
+
     def test_concurrent_cancellation_race_condition(self):
         """Test that concurrent cancellation attempts don't cause errors."""
         self._create_device_firmware(upgrade=True)
@@ -586,6 +603,19 @@ class TestModels(TestUpgraderMixin, TestCase):
         mock_logger.info.assert_called_once_with(
             "Deleted firmware file: %s", "firmware.bin"
         )
+
+    def test_batch_upgrade_disabled_organization(self):
+        env = self._create_upgrade_env()
+        org = env["category"].organization
+        org.is_active = False
+        org.save(update_fields=["is_active"])
+        with self.assertRaises(ValidationError) as cm:
+            env["build2"].batch_upgrade(firmwareless=False)
+        self.assertIn(
+            "Firmware upgrades are not allowed for disabled organizations.",
+            str(cm.exception),
+        )
+        self.assertEqual(BatchUpgradeOperation.objects.count(), 0)
 
     def test_batch_upgrade_operation_str(self):
         build = self._create_build()
@@ -1082,6 +1112,95 @@ class TestModelsTransaction(TestUpgraderMixin, TransactionTestCase):
     )
     @mock.patch("openwisp_firmware_upgrader.websockets._run_coroutine_safely")
     @mock.patch("openwisp_firmware_upgrader.tasks.upgrade_firmware.delay")
+    def test_batch_upgrade_excludes_disabled_organization_devices(self, *args):
+        shared_category = self._create_category(organization=None)
+        active_org = self._get_org()
+        disabled_org = self._create_org(name="disabled-org")
+        build = self._create_build(category=shared_category, version="0.1")
+        image = self._create_firmware_image(build=build)
+        self._create_credentials(organization=None, auto_add=True)
+        active_device = self._create_device(
+            name="active-device",
+            organization=active_org,
+            model=image.boards[0],
+            mac_address="00:11:22:33:66:01",
+        )
+        disabled_org_device = self._create_device(
+            name="disabled-org-device",
+            organization=disabled_org,
+            model=image.boards[0],
+            mac_address="00:11:22:33:66:02",
+        )
+        self._create_config(device=active_device)
+        self._create_config(device=disabled_org_device)
+        disabled_org.is_active = False
+        disabled_org.save(update_fields=["is_active"])
+
+        with self.subTest("firmwareless target resolution"):
+            result = BatchUpgradeOperation.dry_run(build=build)
+            self.assertEqual(result["devices"].count(), 1)
+            result_device = result["devices"].first()
+            self.assertEqual(result_device.pk, active_device.pk)
+            self.assertNotEqual(result_device.pk, disabled_org_device.pk)
+
+        with self.subTest("related device_firmware target resolution"):
+            build2 = self._create_build(category=shared_category, version="0.2")
+            with mock.patch(
+                "openwisp_firmware_upgrader.base.models."
+                "AbstractDeviceFirmware.create_upgrade_operation"
+            ):
+                DeviceFirmware.objects.create(
+                    device=active_device, image=image, installed=True
+                )
+                DeviceFirmware.objects.create(
+                    device=disabled_org_device, image=image, installed=True
+                )
+            result = BatchUpgradeOperation.dry_run(build=build2)
+            device_ids = [
+                fw.device.pk
+                for fw in result["device_firmwares"].select_related("device")
+            ]
+            self.assertIn(active_device.pk, device_ids)
+            self.assertNotIn(disabled_org_device.pk, device_ids)
+
+    @mock.patch(
+        "openwisp_controller.connection.apps.ConnectionConfig._launch_update_config"
+    )
+    def test_batch_upgrade_cancelled_when_organization_disabled_before_worker_runs(
+        self, *_args
+    ):
+        env = self._create_upgrade_env()
+        batch = BatchUpgradeOperation(build=env["build2"])
+        batch.full_clean()
+        batch.save()
+        org = env["category"].organization
+        org.is_active = False
+        org.save(update_fields=["is_active"])
+        batch.upgrade(firmwareless=False)
+        batch.refresh_from_db()
+        self.assertEqual(batch.status, "cancelled")
+        self.assertEqual(batch.upgradeoperation_set.count(), 0)
+
+    @mock.patch(
+        "openwisp_controller.connection.apps.ConnectionConfig._launch_update_config"
+    )
+    def test_batch_upgrade_zero_operations_marked_cancelled(self, *_args):
+        env = self._create_upgrade_env()
+        env["d1"].deactivate()
+        env["d2"].deactivate()
+        batch = BatchUpgradeOperation(build=env["build2"])
+        batch.full_clean()
+        batch.save()
+        batch.upgrade(firmwareless=False)
+        batch.refresh_from_db()
+        self.assertEqual(batch.status, "cancelled")
+        self.assertEqual(batch.upgradeoperation_set.count(), 0)
+
+    @mock.patch(
+        "openwisp_controller.connection.apps.ConnectionConfig._launch_update_config"
+    )
+    @mock.patch("openwisp_firmware_upgrader.websockets._run_coroutine_safely")
+    @mock.patch("openwisp_firmware_upgrader.tasks.upgrade_firmware.delay")
     def test_batch_upgrade_excludes_deactivated_devices(self, *args):
         env = self._create_upgrade_env()
         # Test firmwareless=False case (devices with existing DeviceFirmware)
@@ -1158,3 +1277,36 @@ class TestModelsTransaction(TestUpgraderMixin, TransactionTestCase):
             "Upgrade operations are not allowed for deactivated devices.",
             str(cm.exception),
         )
+
+    def test_disabled_organization_validation(self):
+        device_fw = self._create_device_firmware()
+        device = device_fw.device
+        org = device.organization
+        org.is_active = False
+        org.save(update_fields=["is_active"])
+
+        with self.subTest("DeviceFirmware validation"):
+            with self.assertRaises(ValidationError) as cm:
+                new_device_fw = DeviceFirmware(device=device, image=device_fw.image)
+                new_device_fw.full_clean()
+            self.assertIn(
+                "Firmware upgrades are not allowed for disabled organizations.",
+                str(cm.exception),
+            )
+
+        with self.subTest("UpgradeOperation validation"):
+            with self.assertRaises(ValidationError) as cm:
+                operation = UpgradeOperation(device=device, image=device_fw.image)
+                operation.full_clean()
+            self.assertIn(
+                "Upgrade operations are not allowed for disabled organizations.",
+                str(cm.exception),
+            )
+
+        with self.subTest("DeviceFirmware.save(upgrade=True) raises and creates no op"):
+            uo_count = UpgradeOperation.objects.count()
+            with self.assertRaises(ValidationError):
+                device_fw.installed = False
+                device_fw.full_clean()
+                device_fw.save(upgrade=True)
+            self.assertEqual(UpgradeOperation.objects.count(), uo_count)

--- a/openwisp_firmware_upgrader/tests/test_models.py
+++ b/openwisp_firmware_upgrader/tests/test_models.py
@@ -1305,8 +1305,13 @@ class TestModelsTransaction(TestUpgraderMixin, TransactionTestCase):
 
         with self.subTest("DeviceFirmware.save(upgrade=True) raises and creates no op"):
             uo_count = UpgradeOperation.objects.count()
+            device_fw.installed = False
             with self.assertRaises(ValidationError):
-                device_fw.installed = False
                 device_fw.full_clean()
+            with self.assertRaises(ValidationError) as cm:
                 device_fw.save(upgrade=True)
+            self.assertIn(
+                "Upgrade operations are not allowed for disabled organizations.",
+                str(cm.exception),
+            )
             self.assertEqual(UpgradeOperation.objects.count(), uo_count)

--- a/openwisp_firmware_upgrader/tests/test_models.py
+++ b/openwisp_firmware_upgrader/tests/test_models.py
@@ -13,6 +13,7 @@ from django.utils import timezone
 from openwisp_utils.tests import capture_any_output
 
 from .. import settings as app_settings
+from ..exceptions import RecoverableFailure
 from ..hardware import FIRMWARE_IMAGE_MAP, REVERSE_FIRMWARE_IMAGE_MAP
 from ..swapper import load_model
 from ..tasks import upgrade_firmware
@@ -301,6 +302,20 @@ class TestModels(TestUpgraderMixin, TestCase):
         uo.refresh_from_db()
         self.assertEqual(uo.log, "line1\nline2")
 
+    def test_upgrade_operation_progress_persist_after_organization_disabled(self):
+        device_fw = self._create_device_firmware()
+        uo = UpgradeOperation(device=device_fw.device, image=device_fw.image)
+        uo.full_clean()
+        uo.save()
+        org = device_fw.device.organization
+        org.is_active = False
+        org.save(update_fields=["is_active"])
+        uo.log_line("line1")
+        uo.update_progress(50)
+        uo.refresh_from_db()
+        self.assertEqual(uo.log, "line1")
+        self.assertEqual(uo.progress, 50)
+
     def test_upgrade_operation_update_progress(self):
         self._create_device_firmware(upgrade=True)
         uo = UpgradeOperation.objects.first()
@@ -434,6 +449,37 @@ class TestModels(TestUpgraderMixin, TestCase):
         FirmwareImage.objects.get(pk=device_fw.image.pk).delete()
         self.assertEqual(UpgradeOperation.objects.get(pk=uo.pk).image, None)
 
+    def test_delete_firmware_image_aborts_in_progress_upgrade_operation(self):
+        device_fw = self._create_device_firmware()
+        batch = BatchUpgradeOperation.objects.create(build=device_fw.image.build)
+        op = UpgradeOperation.objects.create(
+            device=device_fw.device, image=device_fw.image, batch=batch
+        )
+        self.assertEqual(op.status, "in-progress")
+        device_fw.image.delete()
+        op.refresh_from_db()
+        self.assertEqual(op.status, "aborted")
+        self.assertIn(
+            "Upgrade aborted because the firmware image has been deleted.", op.log
+        )
+        self.assertIsNone(op.image)
+        batch.refresh_from_db()
+        self.assertEqual(batch.status, "failed")
+
+    def test_delete_firmware_build_aborts_in_progress_upgrade_operation(self):
+        device_fw = self._create_device_firmware()
+        build = device_fw.image.build
+        op = UpgradeOperation.objects.create(
+            device=device_fw.device, image=device_fw.image
+        )
+        build.delete()
+        op.refresh_from_db()
+        self.assertEqual(op.status, "aborted")
+        self.assertIn(
+            "Upgrade aborted because the firmware image has been deleted.", op.log
+        )
+        self.assertIsNone(op.image)
+
     def test_delete_firmware_image_file(self):
         file_storage_backend = FirmwareImage.file.field.storage
 
@@ -457,9 +503,9 @@ class TestModels(TestUpgraderMixin, TestCase):
     def test_schedule_firmware_file_deletion_with_files(
         self, mock_fw_image_manager, mock_on_commit
     ):
-        mock_image1 = MagicMock()
+        mock_image1 = FirmwareImage()
         mock_image1.file.name = "build/123/image1.bin"
-        mock_image2 = MagicMock()
+        mock_image2 = FirmwareImage()
         mock_image2.file.name = "build/123/image2.bin"
         mocked_qs_result = MagicMock()
         mocked_qs_result.iterator.return_value = [mock_image1, mock_image2]
@@ -488,11 +534,11 @@ class TestModels(TestUpgraderMixin, TestCase):
     def test_schedule_firmware_file_deletion_files_without_names(
         self, mock_fw_image_manager, mock_on_commit
     ):
-        mock_image1 = MagicMock()
+        mock_image1 = FirmwareImage()
         mock_image1.file.name = "build/123/image1.bin"
-        mock_image2 = MagicMock()
+        mock_image2 = FirmwareImage()
         mock_image2.file.name = None  # No file name
-        mock_image3 = MagicMock()
+        mock_image3 = FirmwareImage()
         mock_image3.file.name = ""  # Empty file name
         mocked_qs_result = MagicMock()
         mocked_qs_result.iterator.return_value = [
@@ -752,6 +798,58 @@ class TestModelsTransaction(TestUpgraderMixin, TransactionTestCase):
         batch = BatchUpgradeOperation.objects.first()
         self.assertEqual(batch.status, "in-progress")
 
+    def test_upgrade_retry_aborts_after_deactivation_or_disabled_org(self):
+        cases = (
+            ("deactivated-device", lambda device: device.deactivate()),
+            (
+                "disabled-organization",
+                lambda device: (
+                    setattr(device.organization, "is_active", False),
+                    device.organization.save(update_fields=["is_active"]),
+                ),
+            ),
+        )
+        for label, disable in cases:
+            with self.subTest(label):
+                # Each case needs its own org/build/device: reusing the
+                # defaults across subTests would hit their unique_together
+                # constraints, since this is a TransactionTestCase and
+                # nothing is rolled back between subTests.
+                org = self._create_org(name=label, slug=label)
+                category = self._create_category(name=label, organization=org)
+                build = self._create_build(category=category, version="0.1")
+                image = self._create_firmware_image(build=build)
+                device = self._create_device(
+                    name=label, organization=org, model=image.boards[0]
+                )
+                self._create_config(device=device)
+                self._create_device_connection(device=device)
+                device_fw = DeviceFirmware(device=device, image=image)
+                device_fw.full_clean()
+                device_fw.save(upgrade=False)
+                operation = UpgradeOperation(
+                    device=device_fw.device, image=device_fw.image
+                )
+                operation.full_clean()
+                operation.save()
+                with mock.patch.object(
+                    DeviceConnection,
+                    "get_working_connection",
+                    side_effect=RecoverableFailure("connection error"),
+                ):
+                    with self.assertRaises(RecoverableFailure):
+                        operation.upgrade()
+                operation.refresh_from_db()
+                self.assertEqual(operation.status, "in-progress")
+                disable(device_fw.device)
+                with mock.patch.object(
+                    DeviceConnection, "get_working_connection"
+                ) as mocked:
+                    operation.upgrade()
+                mocked.assert_not_called()
+                operation.refresh_from_db()
+                self.assertEqual(operation.status, "aborted")
+
     def test_device_fw_not_created_on_device_connection_save(self):
         org = self._get_org()
         category = self._get_category(organization=org)
@@ -850,6 +948,26 @@ class TestModelsTransaction(TestUpgraderMixin, TransactionTestCase):
         org.delete()
         # Check that the file was deleted
         self.assertEqual(file_storage_backend.exists(file_name), False)
+
+    def test_delete_firmware_files_of_disabled_organization(self):
+        file_storage_backend = FirmwareImage.file.field.storage
+        org = self._create_org(name="disabled-org")
+        category = self._create_category(organization=org)
+        build = self._create_build(category=category)
+        image = self._create_firmware_image(build=build)
+        file_name = image.file.name
+        org.is_active = False
+        org.save(update_fields=["is_active"])
+
+        with self.subTest("Direct image delete still removes the file"):
+            image.delete()
+            self.assertEqual(file_storage_backend.exists(file_name), False)
+
+        with self.subTest("Build delete of a disabled org still schedules cleanup"):
+            image2 = self._create_firmware_image(build=build)
+            file_name2 = image2.file.name
+            build.delete()
+            self.assertEqual(file_storage_backend.exists(file_name2), False)
 
     @mock.patch(_mock_updrade, return_value=True)
     def test_batch_upgrade_with_group_filtering(self, *_args):
@@ -1162,6 +1280,34 @@ class TestModelsTransaction(TestUpgraderMixin, TransactionTestCase):
             ]
             self.assertIn(active_device.pk, device_ids)
             self.assertNotIn(disabled_org_device.pk, device_ids)
+
+    @mock.patch(
+        "openwisp_controller.connection.apps.ConnectionConfig._launch_update_config"
+    )
+    def test_batch_status_recalculated_with_existing_operations_after_org_disabled(
+        self, *_args
+    ):
+        env = self._create_upgrade_env()
+        batch = BatchUpgradeOperation.objects.create(build=env["build2"])
+        op1 = UpgradeOperation.objects.create(
+            device=env["d1"], image=env["image2a"], batch=batch, status="in-progress"
+        )
+        op2 = UpgradeOperation.objects.create(
+            device=env["d2"], image=env["image2b"], batch=batch, status="in-progress"
+        )
+        org = env["category"].organization
+        org.is_active = False
+        org.save(update_fields=["is_active"])
+
+        op1.status = "success"
+        op1.save()
+        batch.refresh_from_db()
+        self.assertEqual(batch.status, "in-progress")
+
+        op2.status = "success"
+        op2.save()
+        batch.refresh_from_db()
+        self.assertEqual(batch.status, "success")
 
     @mock.patch(
         "openwisp_controller.connection.apps.ConnectionConfig._launch_update_config"

--- a/openwisp_firmware_upgrader/tests/test_private_storage.py
+++ b/openwisp_firmware_upgrader/tests/test_private_storage.py
@@ -1,5 +1,5 @@
 import swapper
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase
 from django.urls import reverse
 
 from openwisp_users.tests.utils import TestMultitenantAdminMixin
@@ -30,6 +30,14 @@ class TestPrivateStorage(
     def get_download_url(self):
         """Return the private storage firmware download URL"""
         return reverse("serve_private_file", args=[self.image.file])
+
+
+class TestPrivateStorageTransaction(
+    TestUpgraderMixin, TestMultitenantAdminMixin, TransactionTestCase
+):
+    def setUp(self):
+        self._ensure_default_group_permissions()
+        super().setUp()
 
     def test_firmware_download_disabled_organization(self):
         org = self._create_org(name="disabled-download-org")

--- a/openwisp_firmware_upgrader/tests/test_private_storage.py
+++ b/openwisp_firmware_upgrader/tests/test_private_storage.py
@@ -30,3 +30,14 @@ class TestPrivateStorage(
     def get_download_url(self):
         """Return the private storage firmware download URL"""
         return reverse("serve_private_file", args=[self.image.file])
+
+    def test_firmware_download_disabled_organization_still_allowed(self):
+        org = self._create_org(name="disabled-download-org")
+        image = self._create_firmware_image(organization=org)
+        org.is_active = False
+        org.save(update_fields=["is_active"])
+        user = self._get_admin()
+        self.client.force_login(user)
+        url = reverse("serve_private_file", args=[image.file])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)

--- a/openwisp_firmware_upgrader/tests/test_private_storage.py
+++ b/openwisp_firmware_upgrader/tests/test_private_storage.py
@@ -31,13 +31,21 @@ class TestPrivateStorage(
         """Return the private storage firmware download URL"""
         return reverse("serve_private_file", args=[self.image.file])
 
-    def test_firmware_download_disabled_organization_still_allowed(self):
+    def test_firmware_download_disabled_organization(self):
         org = self._create_org(name="disabled-download-org")
+        administrator = self._create_administrator(organizations=[org])
+        admin = self._get_admin()
         image = self._create_firmware_image(organization=org)
         org.is_active = False
         org.save(update_fields=["is_active"])
-        user = self._get_admin()
-        self.client.force_login(user)
         url = reverse("serve_private_file", args=[image.file])
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+
+        with self.subTest("Disabling org revokes org manager status"):
+            self.client.force_login(administrator)
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 403)
+
+        with self.subTest("Superuser can download firmware from disabled org"):
+            self.client.force_login(admin)
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 200)

--- a/openwisp_firmware_upgrader/tests/test_tasks.py
+++ b/openwisp_firmware_upgrader/tests/test_tasks.py
@@ -1,6 +1,5 @@
 from unittest import mock
 
-import swapper
 from celery.exceptions import SoftTimeLimitExceeded
 from django.test import TransactionTestCase
 
@@ -12,9 +11,7 @@ from .base import TestUpgraderMixin
 
 BatchUpgradeOperation = load_model("BatchUpgradeOperation")
 DeviceFirmware = load_model("DeviceFirmware")
-FirmwareImage = load_model("FirmwareImage")
 UpgradeOperation = load_model("UpgradeOperation")
-DeviceConnection = swapper.load_model("connection", "DeviceConnection")
 
 
 class TestTasks(TestUpgraderMixin, TransactionTestCase):
@@ -114,6 +111,7 @@ class TestTasks(TestUpgraderMixin, TransactionTestCase):
         credentials = self._create_credentials(organization=None, auto_add=False)
 
         with self.subTest("deactivated device"):
+            mocked_delay.reset_mock()
             device = self._create_device(
                 name="deactivated-device",
                 organization=org,
@@ -128,6 +126,7 @@ class TestTasks(TestUpgraderMixin, TransactionTestCase):
             self.assertEqual(DeviceFirmware.objects.filter(device=device).count(), 0)
 
         with self.subTest("disabled organization device"):
+            mocked_delay.reset_mock()
             disabled_org = self._create_org(name="disabled-org")
             device = self._create_device(
                 name="disabled-org-device",

--- a/openwisp_firmware_upgrader/tests/test_tasks.py
+++ b/openwisp_firmware_upgrader/tests/test_tasks.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+import swapper
 from celery.exceptions import SoftTimeLimitExceeded
 from django.test import TransactionTestCase
 
@@ -12,6 +13,7 @@ from .base import TestUpgraderMixin
 BatchUpgradeOperation = load_model("BatchUpgradeOperation")
 DeviceFirmware = load_model("DeviceFirmware")
 UpgradeOperation = load_model("UpgradeOperation")
+DeviceConnection = swapper.load_model("connection", "DeviceConnection")
 
 
 class TestTasks(TestUpgraderMixin, TransactionTestCase):
@@ -67,6 +69,47 @@ class TestTasks(TestUpgraderMixin, TransactionTestCase):
             mocked_logger.assert_called_with(
                 f"The BatchUpgradeOperation object with id {batch_id} has been deleted"
             )
+
+    def test_upgrade_firmware_task_aborts_for_deactivated_device_or_disabled_org(self):
+        cases = (
+            ("deactivated-device", lambda device: device.deactivate()),
+            (
+                "disabled-organization",
+                lambda device: (
+                    setattr(device.organization, "is_active", False),
+                    device.organization.save(update_fields=["is_active"]),
+                ),
+            ),
+        )
+        for label, disable in cases:
+            with self.subTest(label):
+                # Each case needs its own org/build/device: reusing the
+                # defaults across subTests would hit their unique_together
+                # constraints, since this is a TransactionTestCase and
+                # nothing is rolled back between subTests.
+                org = self._create_org(name=label, slug=label)
+                category = self._create_category(name=label, organization=org)
+                build = self._create_build(category=category, version="0.1")
+                image = self._create_firmware_image(build=build)
+                device = self._create_device(
+                    name=label, organization=org, model=image.boards[0]
+                )
+                self._create_config(device=device)
+                self._create_device_connection(device=device)
+                device_fw = DeviceFirmware(device=device, image=image)
+                device_fw.full_clean()
+                device_fw.save(upgrade=False)
+                operation = UpgradeOperation.objects.create(
+                    device=device_fw.device, image=device_fw.image
+                )
+                disable(device_fw.device)
+                with mock.patch.object(
+                    DeviceConnection, "get_working_connection"
+                ) as mocked:
+                    tasks.upgrade_firmware.run(operation.pk)
+                mocked.assert_not_called()
+                operation.refresh_from_db()
+                self.assertEqual(operation.status, "aborted")
 
     def test_create_all_device_firmwares_excludes_deactivated_and_disabled_org(self):
         org = self._get_org()

--- a/openwisp_firmware_upgrader/tests/test_tasks.py
+++ b/openwisp_firmware_upgrader/tests/test_tasks.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+import swapper
 from celery.exceptions import SoftTimeLimitExceeded
 from django.test import TransactionTestCase
 
@@ -10,7 +11,10 @@ from ..swapper import load_model
 from .base import TestUpgraderMixin
 
 BatchUpgradeOperation = load_model("BatchUpgradeOperation")
+DeviceFirmware = load_model("DeviceFirmware")
+FirmwareImage = load_model("FirmwareImage")
 UpgradeOperation = load_model("UpgradeOperation")
+DeviceConnection = swapper.load_model("connection", "DeviceConnection")
 
 
 class TestTasks(TestUpgraderMixin, TransactionTestCase):
@@ -66,3 +70,75 @@ class TestTasks(TestUpgraderMixin, TransactionTestCase):
             mocked_logger.assert_called_with(
                 f"The BatchUpgradeOperation object with id {batch_id} has been deleted"
             )
+
+    def test_create_all_device_firmwares_excludes_deactivated_and_disabled_org(self):
+        org = self._get_org()
+        category = self._get_category(organization=org)
+        build = self._create_build(category=category, version="0.1", os="TestOS")
+        image = self._create_firmware_image(build=build)
+
+        with self.subTest("deactivated device"):
+            device = self._create_device(
+                name="deactivated-device",
+                organization=org,
+                os="TestOS",
+                model=image.boards[0],
+                mac_address="00:11:22:33:77:01",
+            )
+            device.deactivate()
+            tasks.create_all_device_firmwares.run(image.pk)
+            self.assertEqual(DeviceFirmware.objects.filter(device=device).count(), 0)
+
+        with self.subTest("disabled organization device"):
+            disabled_org = self._create_org(name="disabled-org")
+            device = self._create_device(
+                name="disabled-org-device",
+                organization=disabled_org,
+                os="TestOS",
+                model=image.boards[0],
+                mac_address="00:11:22:33:77:02",
+            )
+            disabled_org.is_active = False
+            disabled_org.save(update_fields=["is_active"])
+            tasks.create_all_device_firmwares.run(image.pk)
+            self.assertEqual(DeviceFirmware.objects.filter(device=device).count(), 0)
+
+    @mock.patch("openwisp_firmware_upgrader.tasks.create_device_firmware.delay")
+    def test_create_device_firmware_not_queued_for_deactivated_or_disabled_org(
+        self, mocked_delay
+    ):
+        org = self._get_org()
+        category = self._get_category(organization=org)
+        build = self._create_build(category=category, version="0.1", os="TestOS")
+        image = self._create_firmware_image(build=build)
+        credentials = self._create_credentials(organization=None, auto_add=False)
+
+        with self.subTest("deactivated device"):
+            device = self._create_device(
+                name="deactivated-device",
+                organization=org,
+                os="TestOS",
+                model=image.boards[0],
+                mac_address="00:11:22:33:88:01",
+            )
+            self._create_config(device=device)
+            device.deactivate()
+            self._create_device_connection(device=device, credentials=credentials)
+            mocked_delay.assert_not_called()
+            self.assertEqual(DeviceFirmware.objects.filter(device=device).count(), 0)
+
+        with self.subTest("disabled organization device"):
+            disabled_org = self._create_org(name="disabled-org")
+            device = self._create_device(
+                name="disabled-org-device",
+                organization=disabled_org,
+                os="TestOS",
+                model=image.boards[0],
+                mac_address="00:11:22:33:88:02",
+            )
+            self._create_config(device=device)
+            disabled_org.is_active = False
+            disabled_org.save(update_fields=["is_active"])
+            self._create_device_connection(device=device, credentials=credentials)
+            mocked_delay.assert_not_called()
+            self.assertEqual(DeviceFirmware.objects.filter(device=device).count(), 0)

--- a/openwisp_firmware_upgrader/tests/test_websockets.py
+++ b/openwisp_firmware_upgrader/tests/test_websockets.py
@@ -700,3 +700,31 @@ class TestFirmwareUpgradeSockets(TestUpgraderMixin, TransactionTestCase):
         # Assert that we received exactly ONE log message (not duplicates)
         self.assertEqual(len(messages), 1)
         await communicator.disconnect()
+
+    @override_settings(
+        CHANNEL_LAYERS={"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}}
+    )
+    async def test_progress_published_after_organization_disabled(self):
+        """
+        Progress and status updates must keep being published even after the
+        device's organization has been disabled: notification is never
+        blocked, only new writes/upgrades are.
+        """
+        device_fw = await sync_to_async(self._create_device_firmware)(upgrade=False)
+        operation = await sync_to_async(UpgradeOperation.objects.create)(
+            device=device_fw.device,
+            image=device_fw.image,
+            status="in-progress",
+        )
+        org = await sync_to_async(lambda: device_fw.device.organization)()
+        org.is_active = False
+        await sync_to_async(org.save)(update_fields=["is_active"])
+
+        communicator = await self._get_upgrade_progress_communicator(
+            str(operation.pk), user=self.superuser
+        )
+        await sync_to_async(operation.update_progress)(50)
+        response = await asyncio.wait_for(communicator.receive_json_from(), timeout=2)
+        self.assertEqual(response["type"], "operation_update")
+        self.assertEqual(response["operation"]["progress"], 50)
+        await communicator.disconnect()

--- a/tests/openwisp2/sample_connection/tests.py
+++ b/tests/openwisp2/sample_connection/tests.py
@@ -76,7 +76,7 @@ class TestConnectionApi(BaseTestConnectionApi):
             "enabled": True,
             "failure_reason": "",
         }
-        with self.assertNumQueries(13):
+        with self.assertNumQueries(14):
             response = self.client.post(path, data, content_type="application/json")
         self.assertEqual(response.status_code, 201)
 

--- a/tests/openwisp2/sample_firmware_upgrader/tests.py
+++ b/tests/openwisp2/sample_firmware_upgrader/tests.py
@@ -5,6 +5,7 @@ from openwisp_firmware_upgrader.tests.test_admin import TestAdmin as BaseTestAdm
 from openwisp_firmware_upgrader.tests.test_admin import (
     TestAdminTransaction as BaseTestAdminTransaction,
 )
+from openwisp_firmware_upgrader.tests.test_api import TestApiMisc as BaseTestApiMisc
 from openwisp_firmware_upgrader.tests.test_api import (
     TestBatchUpgradeOperationViews as BaseTestBatchUpgradeOperationViews,
 )
@@ -12,10 +13,25 @@ from openwisp_firmware_upgrader.tests.test_api import (
     TestBuildViews as BaseTestBuildViews,
 )
 from openwisp_firmware_upgrader.tests.test_api import (
+    TestBuildViewsTransaction as BaseTestBuildViewsTransaction,
+)
+from openwisp_firmware_upgrader.tests.test_api import (
     TestCategoryViews as BaseTestCategoryViews,
 )
 from openwisp_firmware_upgrader.tests.test_api import (
+    TestCategoryViewsTransaction as BaseTestCategoryViewsTransaction,
+)
+from openwisp_firmware_upgrader.tests.test_api import (
+    TestDeviceFirmwareImageViews as BaseTestDeviceFirmwareImageViews,
+)
+from openwisp_firmware_upgrader.tests.test_api import (
+    TestDeviceFirmwareImageViewsTransaction as BaseTestDeviceFirmwareImageViewsTransaction,
+)
+from openwisp_firmware_upgrader.tests.test_api import (
     TestFirmwareImageViews as BaseTestFirmwareImageViews,
+)
+from openwisp_firmware_upgrader.tests.test_api import (
+    TestFirmwareImageViewsTransaction as BaseTestFirmwareImageViewsTransaction,
 )
 from openwisp_firmware_upgrader.tests.test_api import (
     TestOrgAPIMixin as BaseTestOrgAPIMixin,
@@ -29,6 +45,9 @@ from openwisp_firmware_upgrader.tests.test_openwrt_upgrader import (
 )
 from openwisp_firmware_upgrader.tests.test_private_storage import (
     TestPrivateStorage as BaseTestPrivateStorage,
+)
+from openwisp_firmware_upgrader.tests.test_private_storage import (
+    TestPrivateStorageTransaction as BaseTestPrivateStorageTransaction,
 )
 from openwisp_firmware_upgrader.tests.test_selenium import (
     TestDeviceAdmin as BaseTestDeviceAdmin,
@@ -137,6 +156,10 @@ class TestPrivateStorage(BaseTestPrivateStorage):
     pass
 
 
+class TestPrivateStorageTransaction(BaseTestPrivateStorageTransaction):
+    pass
+
+
 class TestDeviceAdmin(BaseTestDeviceAdmin):
     _mock_connect = "openwisp2.sample_connection.models.DeviceConnection.connect"
     pass
@@ -151,7 +174,15 @@ class TestBuildViews(BaseTestBuildViews):
     pass
 
 
+class TestBuildViewsTransaction(BaseTestBuildViewsTransaction):
+    pass
+
+
 class TestCategoryViews(BaseTestCategoryViews):
+    pass
+
+
+class TestCategoryViewsTransaction(BaseTestCategoryViewsTransaction):
     pass
 
 
@@ -163,7 +194,25 @@ class TestFirmwareImageViews(BaseTestFirmwareImageViews):
     pass
 
 
+class TestFirmwareImageViewsTransaction(BaseTestFirmwareImageViewsTransaction):
+    pass
+
+
 class TestOrgAPIMixin(BaseTestOrgAPIMixin):
+    pass
+
+
+class TestDeviceFirmwareImageViews(BaseTestDeviceFirmwareImageViews):
+    pass
+
+
+class TestDeviceFirmwareImageViewsTransaction(
+    BaseTestDeviceFirmwareImageViewsTransaction
+):
+    pass
+
+
+class TestApiMisc(BaseTestApiMisc):
     pass
 
 
@@ -174,10 +223,17 @@ del BaseTestAdminTransaction
 del BaseTestModelsTransaction
 del BaseTestOpenwrtUpgrader
 del BaseTestPrivateStorage
+del BaseTestPrivateStorageTransaction
 del BaseTestDeviceAdmin
 del BaseTestTasks
 del BaseTestBuildViews
+del BaseTestBuildViewsTransaction
 del BaseTestCategoryViews
+del BaseTestCategoryViewsTransaction
 del BaseTestBatchUpgradeOperationViews
 del BaseTestFirmwareImageViews
+del BaseTestFirmwareImageViewsTransaction
 del BaseTestOrgAPIMixin
+del BaseTestDeviceFirmwareImageViews
+del BaseTestDeviceFirmwareImageViewsTransaction
+del BaseTestApiMisc


### PR DESCRIPTION




## Checklist

<!-- Pull requests not following the rules will be closed without further inspection. -->
<!-- Replace `[ ]` with `N/A` if the requirement is not applicable. -->

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

<!-- Please [open a new issue](https://github.com/openwisp/openwisp-firmware-upgrader/issues/new/choose) if there isn't an existing issue yet. -->

Closes #445

## Description of Changes

Firmware upgrades are now blocked for devices belonging to disabled organizations.

Validation is enforced when:

- assigning a DeviceFirmware or creating an UpgradeOperation
- starting a mass upgrade through the REST API or admin
- resolving targets for a mass upgrade
- executing queued upgrade operations
- automatically creating DeviceFirmwares

Queued upgrades recheck the organization status before execution. Batch upgrades with no valid operations are cancelled instead of remaining in progress. Shared categories continue to work for active organizations.

Existing firmware operations such as reading, deleting, cancelling, reporting progress, and cleaning up firmware files remain unaffected.


## Blockers 

- [ ] https://github.com/openwisp/openwisp-users/pull/542
- [ ] https://github.com/openwisp/openwisp-controller/pull/1456

## Screenshots 

**DeviceFirmware inline is readonly for disabled org / deactivated device** 

<img width="1365" height="656" alt="image" src="https://github.com/user-attachments/assets/bb326133-7f50-4a6d-b121-6eda8ab8087f" />

**Recent Firmware Upgrades are rendered as usual**

<img width="1354" height="2640" alt="image" src="https://github.com/user-attachments/assets/677f4345-6d17-4f2e-a319-8516ad937689" />

**Firmware Category is rendered as readonly for disabled org**

<img width="1365" height="656" alt="image" src="https://github.com/user-attachments/assets/cf5bb61a-403b-44f0-a060-261e4a197ba4" />

**BuildAdmin is rendered as Readonly**

<img width="1354" height="1319" alt="image" src="https://github.com/user-attachments/assets/075a86c0-85b5-4a77-8856-0ded7a73b4b0" />

**Attempting to launch mass upgrade operation from a build of disabled organization** 

[Screencast from 08-15-26 21:00:00.webm](https://github.com/user-attachments/assets/944f219a-7fbc-402c-bdb5-b3a39851d795)


