### PR TITLE
[fix] Optimized create_all_device_firmwares device query #475

### DIFF
--- a/openwisp_firmware_upgrader/tasks.py
+++ b/openwisp_firmware_upgrader/tasks.py
@@ -78,9 +78,22 @@ def create_all_device_firmwares(self, firmware_image_id):
     FirmwareImage = load_model("FirmwareImage")
     Device = swapper.load_model("config", "Device")
 
-    fw_image = FirmwareImage.objects.select_related("build").get(pk=firmware_image_id)
+    fw_image = FirmwareImage.objects.select_related("build__category").get(
+        pk=firmware_image_id
+    )
+    if not fw_image.build.os:
+        return
 
-    queryset = Device.objects.filter(os=fw_image.build.os)
+    queryset = Device.objects.filter(
+        os=fw_image.build.os,
+        model__in=fw_image.boards,
+        devicefirmware__isnull=True,
+        _is_deactivated=False,
+    )
+    if fw_image.build.category.organization_id:
+        queryset = queryset.filter(
+            organization_id=fw_image.build.category.organization_id
+        )
     for device in queryset.iterator():
         DeviceFirmware.create_for_device(device, fw_image)
 

--- a/openwisp_firmware_upgrader/tests/base.py
+++ b/openwisp_firmware_upgrader/tests/base.py
@@ -198,13 +198,10 @@ class TestUpgraderMixin(CreateConnectionsMixin):
         )
         return d
 
-    def _create_device_with_connection(self, credentials=None, **kwargs):
+    def _create_device_with_connection(self, **kwargs):
         d1 = self._create_device(**kwargs)
         self._create_config(device=d1)
-        connection_kwargs = {"device": d1}
-        if credentials is not None:
-            connection_kwargs["credentials"] = credentials
-        self._create_device_connection(**connection_kwargs)
+        self._create_device_connection(device=d1)
         return d1
 
     def _create_device_group(self, **kwargs):

--- a/openwisp_firmware_upgrader/tests/base.py
+++ b/openwisp_firmware_upgrader/tests/base.py
@@ -198,10 +198,13 @@ class TestUpgraderMixin(CreateConnectionsMixin):
         )
         return d
 
-    def _create_device_with_connection(self, **kwargs):
+    def _create_device_with_connection(self, credentials=None, **kwargs):
         d1 = self._create_device(**kwargs)
         self._create_config(device=d1)
-        self._create_device_connection(device=d1)
+        connection_kwargs = {"device": d1}
+        if credentials is not None:
+            connection_kwargs["credentials"] = credentials
+        self._create_device_connection(**connection_kwargs)
         return d1
 
     def _create_device_group(self, **kwargs):

--- a/openwisp_firmware_upgrader/tests/test_tasks.py
+++ b/openwisp_firmware_upgrader/tests/test_tasks.py
@@ -78,10 +78,6 @@ class TestTasks(TestUpgraderMixin, TransactionTestCase):
         build = self._create_build(organization=org1, os=os_version)
         fw_image = self._create_firmware_image(build=build, type=self.TPLINK_4300_IMAGE)
         supported_board = fw_image.boards[0]
-        # Devices connected below share the same org1 credentials, otherwise
-        # each connection would try to create its own set of credentials
-        # with the same name, which is not allowed.
-        org1_credentials = self._create_credentials(organization=org1)
 
         # 1. Eligible device: matching OS, matching model, no existing firmware, active, same org
         # Patch the auto-create signal handler so that connecting the device
@@ -97,7 +93,6 @@ class TestTasks(TestUpgraderMixin, TransactionTestCase):
                 organization=org1,
                 model=supported_board,
                 os=os_version,
-                credentials=org1_credentials,
             )
         # 2. Ineligible: different hardware model sharing same OS
         d_different_model = self._create_device(
@@ -125,17 +120,16 @@ class TestTasks(TestUpgraderMixin, TransactionTestCase):
         )
         d_deactivated.deactivate()
         # 5. Ineligible: device already has a DeviceFirmware
-        with mock.patch(
-            "openwisp_firmware_upgrader.base.models.create_device_firmware.delay"
-        ):
-            d_existing_fw = self._create_device_with_connection(
-                name="existing-fw-device",
-                mac_address="00:11:22:33:44:05",
-                organization=org1,
-                model=supported_board,
-                os=os_version,
-                credentials=org1_credentials,
-            )
+        # No connection needed here: this device is excluded from the task
+        # by the devicefirmware__isnull filter, so create_for_device is
+        # never called on it.
+        d_existing_fw = self._create_device(
+            name="existing-fw-device",
+            mac_address="00:11:22:33:44:05",
+            organization=org1,
+            model=supported_board,
+            os=os_version,
+        )
         # 6. Ineligible: different OS
         d_different_os = self._create_device(
             name="different-os-device",
@@ -150,9 +144,10 @@ class TestTasks(TestUpgraderMixin, TransactionTestCase):
         old_image = self._create_firmware_image(
             build=old_build, type=self.TPLINK_4300_IMAGE
         )
-        existing_df = DeviceFirmware.objects.create(
+        existing_df = DeviceFirmware(
             device=d_existing_fw, image=old_image, installed=True
         )
+        existing_df.save(upgrade=False)
 
         with mock.patch.object(
             DeviceFirmware, "create_for_device", wraps=DeviceFirmware.create_for_device

--- a/openwisp_firmware_upgrader/tests/test_tasks.py
+++ b/openwisp_firmware_upgrader/tests/test_tasks.py
@@ -78,6 +78,10 @@ class TestTasks(TestUpgraderMixin, TransactionTestCase):
         build = self._create_build(organization=org1, os=os_version)
         fw_image = self._create_firmware_image(build=build, type=self.TPLINK_4300_IMAGE)
         supported_board = fw_image.boards[0]
+        # Devices connected below share the same org1 credentials, otherwise
+        # each connection would try to create its own set of credentials
+        # with the same name, which is not allowed.
+        org1_credentials = self._create_credentials(organization=org1)
 
         # 1. Eligible device: matching OS, matching model, no existing firmware, active, same org
         # Patch the auto-create signal handler so that connecting the device
@@ -93,6 +97,7 @@ class TestTasks(TestUpgraderMixin, TransactionTestCase):
                 organization=org1,
                 model=supported_board,
                 os=os_version,
+                credentials=org1_credentials,
             )
         # 2. Ineligible: different hardware model sharing same OS
         d_different_model = self._create_device(
@@ -129,6 +134,7 @@ class TestTasks(TestUpgraderMixin, TransactionTestCase):
                 organization=org1,
                 model=supported_board,
                 os=os_version,
+                credentials=org1_credentials,
             )
         # 6. Ineligible: different OS
         d_different_os = self._create_device(

--- a/openwisp_firmware_upgrader/tests/test_tasks.py
+++ b/openwisp_firmware_upgrader/tests/test_tasks.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+import swapper
 from celery.exceptions import SoftTimeLimitExceeded
 from django.test import TransactionTestCase
 
@@ -10,7 +11,10 @@ from ..swapper import load_model
 from .base import TestUpgraderMixin
 
 BatchUpgradeOperation = load_model("BatchUpgradeOperation")
+DeviceFirmware = load_model("DeviceFirmware")
+FirmwareImage = load_model("FirmwareImage")
 UpgradeOperation = load_model("UpgradeOperation")
+Device = swapper.load_model("config", "Device")
 
 
 class TestTasks(TestUpgraderMixin, TransactionTestCase):
@@ -66,3 +70,140 @@ class TestTasks(TestUpgraderMixin, TransactionTestCase):
             mocked_logger.assert_called_with(
                 f"The BatchUpgradeOperation object with id {batch_id} has been deleted"
             )
+
+    def test_create_all_device_firmwares_filters_incompatible_devices(self):
+        org1 = self._get_org()
+        org2 = self._create_org(name="Other Org", slug="other-org")
+        os_version = "OpenWrt 23.05.0"
+        build = self._create_build(organization=org1, os=os_version)
+        fw_image = self._create_firmware_image(
+            build=build, type=self.TPLINK_4300_IMAGE
+        )
+        supported_board = fw_image.boards[0]
+
+        # 1. Eligible device: matching OS, matching model, no existing firmware, active, same org
+        d_eligible = self._create_device(
+            name="Eligible Device",
+            mac_address="00:11:22:33:44:01",
+            organization=org1,
+            model=supported_board,
+            os=os_version,
+        )
+        # 2. Ineligible: different hardware model sharing same OS
+        d_different_model = self._create_device(
+            name="Different Model Device",
+            mac_address="00:11:22:33:44:02",
+            organization=org1,
+            model="YunCore XD3200",
+            os=os_version,
+        )
+        # 3. Ineligible: different organization
+        d_different_org = self._create_device(
+            name="Different Org Device",
+            mac_address="00:11:22:33:44:03",
+            organization=org2,
+            model=supported_board,
+            os=os_version,
+        )
+        # 4. Ineligible: deactivated device
+        d_deactivated = self._create_device(
+            name="Deactivated Device",
+            mac_address="00:11:22:33:44:04",
+            organization=org1,
+            model=supported_board,
+            os=os_version,
+        )
+        d_deactivated.deactivate()
+        # 5. Ineligible: device already has a DeviceFirmware
+        d_existing_fw = self._create_device(
+            name="Existing FW Device",
+            mac_address="00:11:22:33:44:05",
+            organization=org1,
+            model=supported_board,
+            os=os_version,
+        )
+        old_build = self._create_build(
+            organization=org1, version="0.0.1", os="OpenWrt 21.02"
+        )
+        old_image = self._create_firmware_image(
+            build=old_build, type=self.TPLINK_4300_IMAGE
+        )
+        existing_df = DeviceFirmware.objects.create(
+            device=d_existing_fw, image=old_image, installed=True
+        )
+
+        with mock.patch.object(
+            DeviceFirmware, "create_for_device", wraps=DeviceFirmware.create_for_device
+        ) as mock_create:
+            tasks.create_all_device_firmwares.run(fw_image.pk)
+            # Ensure create_for_device was only called for the single eligible device
+            self.assertEqual(mock_create.call_count, 1)
+            self.assertEqual(mock_create.call_args[0][0], d_eligible)
+
+        d_eligible.refresh_from_db()
+        self.assertTrue(hasattr(d_eligible, "devicefirmware"))
+        self.assertEqual(d_eligible.devicefirmware.image, fw_image)
+        self.assertEqual(d_eligible.devicefirmware.installed, True)
+
+        d_existing_fw.refresh_from_db()
+        self.assertEqual(d_existing_fw.devicefirmware.pk, existing_df.pk)
+        self.assertEqual(d_existing_fw.devicefirmware.image, old_image)
+
+        for dev in [d_different_model, d_different_org, d_deactivated]:
+            dev.refresh_from_db()
+            self.assertFalse(hasattr(dev, "devicefirmware"))
+
+    def test_create_all_device_firmwares_shared_category(self):
+        org1 = self._get_org()
+        org2 = self._create_org(name="Org 2", slug="org-2")
+        os_version = "OpenWrt 23.05.1"
+        shared_category = self._create_category(
+            name="Shared Category", organization=None
+        )
+        build = self._create_build(category=shared_category, os=os_version)
+        fw_image = self._create_firmware_image(
+            build=build, type=self.TPLINK_4300_IMAGE
+        )
+        supported_board = fw_image.boards[0]
+
+        d_org1 = self._create_device(
+            name="Org1 Device",
+            mac_address="00:11:22:33:44:11",
+            organization=org1,
+            model=supported_board,
+            os=os_version,
+        )
+        d_org2 = self._create_device(
+            name="Org2 Device",
+            mac_address="00:11:22:33:44:12",
+            organization=org2,
+            model=supported_board,
+            os=os_version,
+        )
+
+        tasks.create_all_device_firmwares.run(fw_image.pk)
+
+        d_org1.refresh_from_db()
+        d_org2.refresh_from_db()
+        self.assertEqual(d_org1.devicefirmware.image, fw_image)
+        self.assertEqual(d_org2.devicefirmware.image, fw_image)
+
+    def test_create_all_device_firmwares_no_build_os(self):
+        org = self._get_org()
+        build = self._create_build(organization=org, os=None)
+        fw_image = self._create_firmware_image(
+            build=build, type=self.TPLINK_4300_IMAGE
+        )
+        d = self._create_device(
+            name="Device",
+            organization=org,
+            model=fw_image.boards[0],
+            os="OpenWrt 23.05",
+        )
+
+        with mock.patch.object(DeviceFirmware, "create_for_device") as mock_create:
+            tasks.create_all_device_firmwares.run(fw_image.pk)
+            mock_create.assert_not_called()
+
+        d.refresh_from_db()
+        self.assertFalse(hasattr(d, "devicefirmware"))

--- a/openwisp_firmware_upgrader/tests/test_tasks.py
+++ b/openwisp_firmware_upgrader/tests/test_tasks.py
@@ -82,7 +82,7 @@ class TestTasks(TestUpgraderMixin, TransactionTestCase):
         supported_board = fw_image.boards[0]
 
         # 1. Eligible device: matching OS, matching model, no existing firmware, active, same org
-        d_eligible = self._create_device(
+        d_eligible = self._create_device_with_connection(
             name="Eligible Device",
             mac_address="00:11:22:33:44:01",
             organization=org1,
@@ -115,7 +115,7 @@ class TestTasks(TestUpgraderMixin, TransactionTestCase):
         )
         d_deactivated.deactivate()
         # 5. Ineligible: device already has a DeviceFirmware
-        d_existing_fw = self._create_device(
+        d_existing_fw = self._create_device_with_connection(
             name="Existing FW Device",
             mac_address="00:11:22:33:44:05",
             organization=org1,
@@ -174,14 +174,14 @@ class TestTasks(TestUpgraderMixin, TransactionTestCase):
         )
         supported_board = fw_image.boards[0]
 
-        d_org1 = self._create_device(
+        d_org1 = self._create_device_with_connection(
             name="Org1 Device",
             mac_address="00:11:22:33:44:11",
             organization=org1,
             model=supported_board,
             os=os_version,
         )
-        d_org2 = self._create_device(
+        d_org2 = self._create_device_with_connection(
             name="Org2 Device",
             mac_address="00:11:22:33:44:12",
             organization=org2,
@@ -202,7 +202,7 @@ class TestTasks(TestUpgraderMixin, TransactionTestCase):
         fw_image = self._create_firmware_image(
             build=build, type=self.TPLINK_4300_IMAGE
         )
-        d = self._create_device(
+        d = self._create_device_with_connection(
             name="Device",
             organization=org,
             model=fw_image.boards[0],

--- a/openwisp_firmware_upgrader/tests/test_tasks.py
+++ b/openwisp_firmware_upgrader/tests/test_tasks.py
@@ -122,6 +122,14 @@ class TestTasks(TestUpgraderMixin, TransactionTestCase):
             model=supported_board,
             os=os_version,
         )
+        # 6. Ineligible: different OS
+        d_different_os = self._create_device(
+            name="Different OS Device",
+            mac_address="00:11:22:33:44:06",
+            organization=org1,
+            model=supported_board,
+            os="OpenWrt 21.02.0",
+        )
         old_build = self._create_build(
             organization=org1, version="0.0.1", os="OpenWrt 21.02"
         )
@@ -149,7 +157,7 @@ class TestTasks(TestUpgraderMixin, TransactionTestCase):
         self.assertEqual(d_existing_fw.devicefirmware.pk, existing_df.pk)
         self.assertEqual(d_existing_fw.devicefirmware.image, old_image)
 
-        for dev in [d_different_model, d_different_org, d_deactivated]:
+        for dev in [d_different_model, d_different_org, d_deactivated, d_different_os]:
             dev.refresh_from_db()
             self.assertFalse(hasattr(dev, "devicefirmware"))
 

--- a/openwisp_firmware_upgrader/tests/test_tasks.py
+++ b/openwisp_firmware_upgrader/tests/test_tasks.py
@@ -76,22 +76,27 @@ class TestTasks(TestUpgraderMixin, TransactionTestCase):
         org2 = self._create_org(name="Other Org", slug="other-org")
         os_version = "OpenWrt 23.05.0"
         build = self._create_build(organization=org1, os=os_version)
-        fw_image = self._create_firmware_image(
-            build=build, type=self.TPLINK_4300_IMAGE
-        )
+        fw_image = self._create_firmware_image(build=build, type=self.TPLINK_4300_IMAGE)
         supported_board = fw_image.boards[0]
 
         # 1. Eligible device: matching OS, matching model, no existing firmware, active, same org
-        d_eligible = self._create_device_with_connection(
-            name="Eligible Device",
-            mac_address="00:11:22:33:44:01",
-            organization=org1,
-            model=supported_board,
-            os=os_version,
-        )
+        # Patch the auto-create signal handler so that connecting the device
+        # does not immediately associate a DeviceFirmware, otherwise the
+        # device would no longer be eligible by the time the task under
+        # test runs.
+        with mock.patch(
+            "openwisp_firmware_upgrader.base.models.create_device_firmware.delay"
+        ):
+            d_eligible = self._create_device_with_connection(
+                name="eligible-device",
+                mac_address="00:11:22:33:44:01",
+                organization=org1,
+                model=supported_board,
+                os=os_version,
+            )
         # 2. Ineligible: different hardware model sharing same OS
         d_different_model = self._create_device(
-            name="Different Model Device",
+            name="different-model-device",
             mac_address="00:11:22:33:44:02",
             organization=org1,
             model="YunCore XD3200",
@@ -99,7 +104,7 @@ class TestTasks(TestUpgraderMixin, TransactionTestCase):
         )
         # 3. Ineligible: different organization
         d_different_org = self._create_device(
-            name="Different Org Device",
+            name="different-org-device",
             mac_address="00:11:22:33:44:03",
             organization=org2,
             model=supported_board,
@@ -107,7 +112,7 @@ class TestTasks(TestUpgraderMixin, TransactionTestCase):
         )
         # 4. Ineligible: deactivated device
         d_deactivated = self._create_device(
-            name="Deactivated Device",
+            name="deactivated-device",
             mac_address="00:11:22:33:44:04",
             organization=org1,
             model=supported_board,
@@ -115,16 +120,19 @@ class TestTasks(TestUpgraderMixin, TransactionTestCase):
         )
         d_deactivated.deactivate()
         # 5. Ineligible: device already has a DeviceFirmware
-        d_existing_fw = self._create_device_with_connection(
-            name="Existing FW Device",
-            mac_address="00:11:22:33:44:05",
-            organization=org1,
-            model=supported_board,
-            os=os_version,
-        )
+        with mock.patch(
+            "openwisp_firmware_upgrader.base.models.create_device_firmware.delay"
+        ):
+            d_existing_fw = self._create_device_with_connection(
+                name="existing-fw-device",
+                mac_address="00:11:22:33:44:05",
+                organization=org1,
+                model=supported_board,
+                os=os_version,
+            )
         # 6. Ineligible: different OS
         d_different_os = self._create_device(
-            name="Different OS Device",
+            name="different-os-device",
             mac_address="00:11:22:33:44:06",
             organization=org1,
             model=supported_board,
@@ -169,25 +177,30 @@ class TestTasks(TestUpgraderMixin, TransactionTestCase):
             name="Shared Category", organization=None
         )
         build = self._create_build(category=shared_category, os=os_version)
-        fw_image = self._create_firmware_image(
-            build=build, type=self.TPLINK_4300_IMAGE
-        )
+        fw_image = self._create_firmware_image(build=build, type=self.TPLINK_4300_IMAGE)
         supported_board = fw_image.boards[0]
 
-        d_org1 = self._create_device_with_connection(
-            name="Org1 Device",
-            mac_address="00:11:22:33:44:11",
-            organization=org1,
-            model=supported_board,
-            os=os_version,
-        )
-        d_org2 = self._create_device_with_connection(
-            name="Org2 Device",
-            mac_address="00:11:22:33:44:12",
-            organization=org2,
-            model=supported_board,
-            os=os_version,
-        )
+        # Patch the auto-create signal handler so that connecting the devices
+        # does not immediately associate a DeviceFirmware, otherwise the
+        # devices would no longer be eligible by the time the task under
+        # test runs.
+        with mock.patch(
+            "openwisp_firmware_upgrader.base.models.create_device_firmware.delay"
+        ):
+            d_org1 = self._create_device_with_connection(
+                name="org1-device",
+                mac_address="00:11:22:33:44:11",
+                organization=org1,
+                model=supported_board,
+                os=os_version,
+            )
+            d_org2 = self._create_device_with_connection(
+                name="org2-device",
+                mac_address="00:11:22:33:44:12",
+                organization=org2,
+                model=supported_board,
+                os=os_version,
+            )
 
         tasks.create_all_device_firmwares.run(fw_image.pk)
 
@@ -199,9 +212,7 @@ class TestTasks(TestUpgraderMixin, TransactionTestCase):
     def test_create_all_device_firmwares_no_build_os(self):
         org = self._get_org()
         build = self._create_build(organization=org, os=None)
-        fw_image = self._create_firmware_image(
-            build=build, type=self.TPLINK_4300_IMAGE
-        )
+        fw_image = self._create_firmware_image(build=build, type=self.TPLINK_4300_IMAGE)
         d = self._create_device_with_connection(
             name="Device",
             organization=org,


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation (not applicable for this internal task query optimization).

## Reference to Existing Issue

Closes #475.

## Description of Changes

### Problem & Root Cause
Whenever a new `FirmwareImage` is created, `create_all_device_firmwares` runs a Celery task to associate `DeviceFirmware` to devices matching the build's OS. Previously, the query `Device.objects.filter(os=fw_image.build.os)` fetched all devices with that OS across the entire system without restricting candidate devices at the database level.

This caused `DeviceFirmware.create_for_device` to iterate through:
1. Devices that already had an associated `DeviceFirmware` (failing `OneToOne` unique validation).
2. Devices of different hardware models sharing the same OS version (failing `model in image.boards` validation).
3. Devices from different organizations when the build category is organization-specific.
4. Deactivated devices.

Each failure raised a `ValidationError` in `full_clean()`, which was caught and logged with `logger.warning(e)`, causing high overhead and log pollution in deployments with large device fleets.

### Solution
- Constrained the `Device` queryset in `create_all_device_firmwares` to only target eligible devices:
  - `os=fw_image.build.os`
  - `model__in=fw_image.boards`
  - `devicefirmware__isnull=True`
  - `_is_deactivated=False`
  - `organization_id=fw_image.build.category.organization_id` (when category has an organization)
- Added early return if `fw_image.build.os` is not set.
- Added comprehensive regression tests in `test_tasks.py` covering matching devices, model filtering, multi-tenant organization filtering, deactivated devices, pre-existing firmware, shared categories, and builds without an OS string.
