### PR TITLE
[fix] Relaxed sysupgrade false-positive matching #477

### DIFF
--- a/openwisp_firmware_upgrader/tests/test_openwrt_upgrader.py
+++ b/openwisp_firmware_upgrader/tests/test_openwrt_upgrader.py
@@ -1,5 +1,6 @@
 import io
 from contextlib import redirect_stderr, redirect_stdout
+from functools import partial
 from time import sleep
 from unittest.mock import patch
 
@@ -186,7 +187,11 @@ def mocked_exec_upgrade_memory_aborted(
 
 
 def mocked_exec_upgrade_success_false_positives(
-    command, exit_codes=None, timeout=None, raise_unexpected_exit=None
+    command,
+    exit_codes=None,
+    timeout=None,
+    raise_unexpected_exit=None,
+    options='"save_partitions": 1',
 ):
     if command.startswith(f"{OpenWrt._SYSUPGRADE} -v -c /tmp/openwrt-"):
         filename = command.split()[-1].split("/")[-1]
@@ -196,7 +201,7 @@ def mocked_exec_upgrade_success_false_positives(
             f'"path": "\/tmp\/{filename}", '
             '"backup": "\/tmp\/sysupgrade.tgz", '
             '"command": "\/lib\/upgrade\/do_stage2", '
-            '"options": { "save_partitions": 1 } } '
+            f'"options": {{ {options} }} }} '
             "(Connection failed)"
         )
     return mocked_exec_upgrade_success(
@@ -228,8 +233,11 @@ class TestOpenwrtUpgrader(TestUpgraderMixin, TransactionTestCase):
     def tearDownClass(cls):
         cls.mock_ssh_server.__exit__()
 
-    def _trigger_upgrade(self, upgrade=True, exception=None):
-        ckey = self._create_credentials_with_key(port=self.ssh_server.port)
+    def _trigger_upgrade(self, upgrade=True, exception=None, organization=None):
+        credentials_options = {"port": self.ssh_server.port}
+        if organization:
+            credentials_options["organization"] = organization
+        ckey = self._create_credentials_with_key(**credentials_options)
         device_conn = self._create_device_connection(credentials=ckey)
         build = self._create_build(organization=device_conn.device.organization)
         image = self._create_firmware_image(build=build)
@@ -851,31 +859,52 @@ class TestOpenwrtUpgrader(TestUpgraderMixin, TransactionTestCase):
     @patch.object(OpenWrt, "RECONNECT_DELAY", 0)
     @patch.object(OpenWrt, "RECONNECT_RETRY_DELAY", 0)
     @patch("billiard.Process.is_alive", return_value=True)
-    @patch.object(
-        OpenWrt,
-        "exec_command",
-        side_effect=mocked_exec_upgrade_success_false_positives,
-    )
-    def test_upgrade_success_false_positives(self, exec_command, is_alive, putfo):
-        device_fw, device_conn, upgrade_op, output, _ = self._trigger_upgrade()
-        self.assertTrue(device_conn.is_working)
-        # should be called 6 times but 1 time is
-        # executed in a subprocess and not caught by mock
-        self.assertEqual(upgrade_op.status, "success")
-        self.assertEqual(exec_command.call_count, 9)
-        self.assertEqual(putfo.call_count, 1)
-        self.assertEqual(is_alive.call_count, 1)
-        lines = [
-            "Image checksum file found",
-            "Checksum different, proceeding",
-            "Upgrade operation in progress",
-            "Trying to reconnect to device at 127.0.0.1 (attempt n.1)",
-            "Connected! Writing checksum",
-            "Upgrade completed successfully",
-        ]
-        for line in lines:
-            self.assertIn(line, upgrade_op.log)
-        self.assertTrue(device_fw.installed)
+    def test_upgrade_success_false_positives(self, is_alive, putfo):
+        for name, slug, options in (
+            (
+                "legacy sysupgrade response",
+                "legacy-sysupgrade",
+                '"save_partitions": 1',
+            ),
+            (
+                "newer sysupgrade response with additional options",
+                "newer-sysupgrade",
+                '"save_partitions": 1, "add_provisioning": 0, "future_option": 1',
+            ),
+        ):
+            with self.subTest(name):
+                putfo.reset_mock()
+                is_alive.reset_mock()
+                with patch.object(
+                    OpenWrt,
+                    "exec_command",
+                    side_effect=partial(
+                        mocked_exec_upgrade_success_false_positives,
+                        options=options,
+                    ),
+                ) as exec_command:
+                    device_fw, device_conn, upgrade_op, output, _ = (
+                        self._trigger_upgrade(
+                            organization=self._create_org(name=name, slug=slug)
+                        )
+                    )
+                self.assertTrue(device_conn.is_working)
+                # One command executes in a subprocess and is not caught by the mock.
+                self.assertEqual(upgrade_op.status, "success")
+                self.assertEqual(exec_command.call_count, 9)
+                self.assertEqual(putfo.call_count, 1)
+                self.assertEqual(is_alive.call_count, 1)
+                lines = [
+                    "Image checksum file found",
+                    "Checksum different, proceeding",
+                    "Upgrade operation in progress",
+                    "Trying to reconnect to device at 127.0.0.1 (attempt n.1)",
+                    "Connected! Writing checksum",
+                    "Upgrade completed successfully",
+                ]
+                for line in lines:
+                    self.assertIn(line, upgrade_op.log)
+                self.assertTrue(device_fw.installed)
 
     @patch("scp.SCPClient.putfo")
     def test_upgrade_cancellation_early_stage(self, _mock_putfo):

--- a/openwisp_firmware_upgrader/tests/test_openwrt_upgrader.py
+++ b/openwisp_firmware_upgrader/tests/test_openwrt_upgrader.py
@@ -192,6 +192,7 @@ def mocked_exec_upgrade_success_false_positives(
     timeout=None,
     raise_unexpected_exit=None,
     options='"save_partitions": 1',
+    error_suffix="",
 ):
     if command.startswith(f"{OpenWrt._SYSUPGRADE} -v -c /tmp/openwrt-"):
         filename = command.split()[-1].split("/")[-1]
@@ -203,6 +204,7 @@ def mocked_exec_upgrade_success_false_positives(
             '"command": "\/lib\/upgrade\/do_stage2", '
             f'"options": {{ {options} }} }} '
             "(Connection failed)"
+            f"{error_suffix}"
         )
     return mocked_exec_upgrade_success(
         command, exit_codes, timeout, raise_unexpected_exit
@@ -859,17 +861,28 @@ class TestOpenwrtUpgrader(TestUpgraderMixin, TransactionTestCase):
     @patch.object(OpenWrt, "RECONNECT_DELAY", 0)
     @patch.object(OpenWrt, "RECONNECT_RETRY_DELAY", 0)
     @patch("billiard.Process.is_alive", return_value=True)
-    def test_upgrade_success_false_positives(self, is_alive, putfo):
-        for name, slug, options in (
+    def test_upgrade_false_positives(self, is_alive, putfo):
+        for name, slug, options, error_suffix, expected_status in (
             (
                 "legacy sysupgrade response",
                 "legacy-sysupgrade",
                 '"save_partitions": 1',
+                "",
+                "success",
             ),
             (
                 "newer sysupgrade response with additional options",
                 "newer-sysupgrade",
                 '"save_partitions": 1, "add_provisioning": 0, "future_option": 1',
+                "",
+                "success",
+            ),
+            (
+                "sysupgrade response with trailing diagnostics",
+                "sysupgrade-trailing-diagnostics",
+                '"save_partitions": 1',
+                " Additional reflash diagnostic",
+                "failed",
             ),
         ):
             with self.subTest(name):
@@ -881,6 +894,7 @@ class TestOpenwrtUpgrader(TestUpgraderMixin, TransactionTestCase):
                     side_effect=partial(
                         mocked_exec_upgrade_success_false_positives,
                         options=options,
+                        error_suffix=error_suffix,
                     ),
                 ) as exec_command:
                     device_fw, device_conn, upgrade_op, output, _ = (
@@ -890,21 +904,26 @@ class TestOpenwrtUpgrader(TestUpgraderMixin, TransactionTestCase):
                     )
                 self.assertTrue(device_conn.is_working)
                 # One command executes in a subprocess and is not caught by the mock.
-                self.assertEqual(upgrade_op.status, "success")
-                self.assertEqual(exec_command.call_count, 9)
+                self.assertEqual(upgrade_op.status, expected_status)
                 self.assertEqual(putfo.call_count, 1)
-                self.assertEqual(is_alive.call_count, 1)
-                lines = [
-                    "Image checksum file found",
-                    "Checksum different, proceeding",
-                    "Upgrade operation in progress",
-                    "Trying to reconnect to device at 127.0.0.1 (attempt n.1)",
-                    "Connected! Writing checksum",
-                    "Upgrade completed successfully",
-                ]
+                lines = ["Image checksum file found", "Upgrade operation in progress"]
+                if expected_status == "success":
+                    self.assertEqual(exec_command.call_count, 9)
+                    self.assertEqual(is_alive.call_count, 1)
+                    lines.extend(
+                        [
+                            "Checksum different, proceeding",
+                            "Trying to reconnect to device at 127.0.0.1 (attempt n.1)",
+                            "Connected! Writing checksum",
+                            "Upgrade completed successfully",
+                        ]
+                    )
+                else:
+                    self.assertEqual(is_alive.call_count, 0)
+                    self.assertIn(error_suffix, upgrade_op.log)
                 for line in lines:
                     self.assertIn(line, upgrade_op.log)
-                self.assertTrue(device_fw.installed)
+                self.assertEqual(device_fw.installed, expected_status == "success")
 
     @patch("scp.SCPClient.putfo")
     def test_upgrade_cancellation_early_stage(self, _mock_putfo):

--- a/openwisp_firmware_upgrader/upgraders/openwrt.py
+++ b/openwisp_firmware_upgrader/upgraders/openwrt.py
@@ -94,11 +94,11 @@ class OpenWrt(object):
         '\{ "prefix": "\\\/tmp\\\/root", "path": "[^"]*", '
         '"backup": "\\\/tmp\\\/sysupgrade.tgz", '
         '"command": "\\\/lib\\\/upgrade\\\/do_stage2", '
-        '"options": \{ "save_partitions": 1[^}]*\} \} \(Connection failed\)',
+        '"options": \{ "save_partitions": 1[^}]*\} \} \(Connection failed\)\\s*\\Z',
         "Command failed: ubus call system sysupgrade "
         '\{ "prefix": "\\\/tmp\\\/root", "path": "[^"]*", '
         '"command": "\\\/lib\\\/upgrade\\\/do_stage2", '
-        '"options": \{ "save_partitions": 1[^}]*\} \} \(Connection failed\)',
+        '"options": \{ "save_partitions": 1[^}]*\} \} \(Connection failed\)\\s*\\Z',
     ]
 
     def __init__(self, upgrade_operation, connection):

--- a/openwisp_firmware_upgrader/upgraders/openwrt.py
+++ b/openwisp_firmware_upgrader/upgraders/openwrt.py
@@ -94,11 +94,11 @@ class OpenWrt(object):
         '\{ "prefix": "\\\/tmp\\\/root", "path": "[^"]*", '
         '"backup": "\\\/tmp\\\/sysupgrade.tgz", '
         '"command": "\\\/lib\\\/upgrade\\\/do_stage2", '
-        '"options": \{ "save_partitions": 1 \} \}',
+        '"options": \{ "save_partitions": 1[^}]*\} \} \(Connection failed\)',
         "Command failed: ubus call system sysupgrade "
         '\{ "prefix": "\\\/tmp\\\/root", "path": "[^"]*", '
         '"command": "\\\/lib\\\/upgrade\\\/do_stage2", '
-        '"options": \{ "save_partitions": 1 \} \}',
+        '"options": \{ "save_partitions": 1[^}]*\} \} \(Connection failed\)',
     ]
 
     def __init__(self, upgrade_operation, connection):


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

Closes #477.

## Description of Changes

Updated the OpenWrt sysupgrade false-positive matcher to accept additional options in the expected staged-upgrade connection-failure response while retaining the known command structure and connection-failure condition. Added regression coverage for legacy and additional option payloads.

## Screenshot

N/A