### PR TITLE
[fix] Fixed "All" batch upgrade filter #487

### DIFF
--- a/openwisp_firmware_upgrader/admin.py
+++ b/openwisp_firmware_upgrader/admin.py
@@ -575,6 +575,7 @@ class BatchUpgradeOperationAdmin(BaseUpgradeAdmin):
         status_choices = []
         # build a base QueryDict with all current GET params
         params = request.GET.copy()
+        params.pop("page", None)
 
         # generic choice builder used by both status and organization filters
         def _make_choice(current_value, display, param_name, value):
@@ -585,7 +586,7 @@ class BatchUpgradeOperationAdmin(BaseUpgradeAdmin):
             if value:
                 q[param_name] = value
             qs = q.urlencode()
-            query_string = f"?{qs}" if qs else ""
+            query_string = f"?{qs}"
             return {
                 "display": display,
                 "selected": current_value == value,

--- a/openwisp_firmware_upgrader/tests/test_selenium.py
+++ b/openwisp_firmware_upgrader/tests/test_selenium.py
@@ -273,6 +273,63 @@ class TestDeviceAdmin(TestUpgraderMixin, SeleniumTestMixin, StaticLiveServerTest
                 1,
             )
 
+    def test_batch_upgrade_operation_all_status_filter(self):
+        org, _, _, build2, _, image, device = self._set_up_env()
+        other_device = self._create_device(
+            os=self.os,
+            model=image.boards[0],
+            organization=org,
+            name="other-device",
+            mac_address="00:22:bb:cc:dd:ee",
+        )
+        batch = BatchUpgradeOperation.objects.create(build=build2)
+        UpgradeOperation.objects.create(
+            device=device,
+            image=image,
+            batch=batch,
+            status="in-progress",
+        )
+        UpgradeOperation.objects.create(
+            device=other_device,
+            image=image,
+            batch=batch,
+            status="success",
+        )
+        path = reverse(
+            f"admin:{self.firmware_app_label}_batchupgradeoperation_change",
+            args=[batch.pk],
+        )
+        self.login()
+        self.open(f"{path}?status=in-progress&page=2")
+        self.wait_for_visibility(By.CSS_SELECTOR, "#result_list tbody tr")
+        self.assertEqual(
+            len(self.find_elements(By.CSS_SELECTOR, "#result_list tbody tr")), 1
+        )
+        filter_title = self.find_element(
+            By.CSS_SELECTOR, ".ow-filter.status .filter-title"
+        )
+        self.web_driver.execute_script("arguments[0].click();", filter_title)
+        all_choice = self.find_element(
+            By.CSS_SELECTOR, '.ow-filter.status .filter-options a[title="All"]'
+        )
+        self.web_driver.execute_script("arguments[0].click();", all_choice)
+        self.wait_until(EC.staleness_of(filter_title))
+        self.assertNotIn(
+            "status=",
+            self.web_driver.current_url,
+            "Selecting All should clear the active status filter from the URL.",
+        )
+        self.assertNotIn(
+            "page=",
+            self.web_driver.current_url,
+            "Selecting All should clear the active page from the URL.",
+        )
+        self.assertEqual(
+            len(self.find_elements(By.CSS_SELECTOR, "#result_list tbody tr")),
+            2,
+            "Selecting All should display every upgrade operation.",
+        )
+
     @patch(_mock_upgrade, return_value=True)
     @patch.object(OpenWrt, "SCHEMA", None)
     def test_upgrader_with_unsupported_upgrade_options(self, *args):


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

Closes #487.

## Description of Changes

Fixed the All choice in batch upgrade operation filters so it clears an active status filter and drops stale pagination. Added a Selenium regression test for the browser flow.