### PR TITLE
[feature] Allowed partial custom API view modules #472

### DIFF
--- a/docs/developer/extending.rst
+++ b/docs/developer/extending.rst
@@ -390,6 +390,74 @@ The API code is stored in `openwisp_firmware_upgrader.api
 and is built using `django-rest-framework
 <http://openwisp.io/docs/developer/hacking-openwisp-python-django.html#why-django-rest-framework>`_
 
+The API URL helpers accept a custom views module: ``get_api_urls``
+(imported from ``openwisp_firmware_upgrader.api.urls``) and ``get_urls``
+(imported from ``openwisp_firmware_upgrader.urls``).
+
+The custom views module only needs to define the views you want to
+customize: whenever a view is missing, the helper falls back to the
+standard view, so there is no need to duplicate the full set of views. The
+default API URLs are already loaded automatically by the app with the
+standard views. The following URL configuration is only needed when
+customizing the API views: it must be used instead of the default
+configuration include, so the custom URLs take precedence:
+
+.. code-block:: python
+
+    from django.urls import include, path
+
+    from openwisp_firmware_upgrader.urls import get_urls
+    from myupgrader.api import views as api_views
+
+    urlpatterns = [
+        # ... other urls in your project ...
+        path("", include(get_urls(api_views))),
+    ]
+
+The views module may define only a subset of the views, for example:
+
+.. code-block:: python
+
+    # in myupgrader/api/views.py
+    from openwisp_firmware_upgrader.api.views import (
+        BuildListView as BaseBuildListView,
+    )
+
+
+    class BuildListView(BaseBuildListView):
+        pass
+
+
+    build_list = BuildListView.as_view()
+
+All other views (categories, firmware images, upgrade operations, etc.)
+fall back to the standard implementation. The custom views module must use
+the same attribute names used in ``openwisp_firmware_upgrader.api.views``.
+
+If you want to mount only the API URLs (without the private storage
+routes), use ``get_api_urls`` instead:
+
+.. code-block:: python
+
+    from django.urls import include, path
+
+    from openwisp_firmware_upgrader.api.urls import get_api_urls
+    from myupgrader.api import views as api_views
+
+    urlpatterns = [
+        path(
+            "api/v1/",
+            include(
+                (get_api_urls(api_views), "upgrader"),
+                namespace="upgrader",
+            ),
+        ),
+    ]
+
+``get_api_urls`` preserves URL paths, names and the ``upgrader``
+namespace. Use ``get_urls`` to also get the private storage routes and the
+``FIRMWARE_UPGRADER_API`` setting behavior.
+
 For more information regarding Django REST Framework API views, please
 refer to the `"Generic views" section in the Django REST Framework
 documentation

--- a/openwisp_firmware_upgrader/api/urls.py
+++ b/openwisp_firmware_upgrader/api/urls.py
@@ -4,75 +4,94 @@ from . import views
 
 app_name = "upgrader"
 
-urlpatterns = [
-    path(
-        "firmware-upgrader/",
-        include(
-            [
-                path("build/", views.build_list, name="api_build_list"),
-                path("build/<uuid:pk>/", views.build_detail, name="api_build_detail"),
-                path(
-                    "build/<uuid:pk>/upgrade/",
-                    views.api_batch_upgrade,
-                    name="api_build_batch_upgrade",
-                ),
-                path(
-                    "build/<uuid:build_pk>/image/",
-                    views.firmware_image_list,
-                    name="api_firmware_list",
-                ),
-                path(
-                    "build/<uuid:build_pk>/image/<uuid:pk>/",
-                    views.firmware_image_detail,
-                    name="api_firmware_detail",
-                ),
-                path(
-                    "build/<uuid:build_pk>/image/<pk>/download/",
-                    views.firmware_image_download,
-                    name="api_firmware_download",
-                ),
-                path("category/", views.category_list, name="api_category_list"),
-                path(
-                    "category/<uuid:pk>/",
-                    views.category_detail,
-                    name="api_category_detail",
-                ),
-                path(
-                    "batch-upgrade-operation/",
-                    views.batch_upgrade_operation_list,
-                    name="api_batchupgradeoperation_list",
-                ),
-                path(
-                    "batch-upgrade-operation/<uuid:pk>/",
-                    views.batch_upgrade_operation_detail,
-                    name="api_batchupgradeoperation_detail",
-                ),
-                path(
-                    "upgrade-operation/",
-                    views.upgrade_operation_list,
-                    name="api_upgradeoperation_list",
-                ),
-                path(
-                    "upgrade-operation/<uuid:pk>/",
-                    views.upgrade_operation_detail,
-                    name="api_upgradeoperation_detail",
-                ),
-                path(
-                    "upgrade-operation/<uuid:pk>/cancel/",
-                    views.upgrade_operation_cancel,
-                    name="api_upgradeoperation_cancel",
-                ),
-                path(
-                    "device/<uuid:pk>/upgrade-operation/",
-                    views.device_upgrade_operation_list,
-                    name="api_deviceupgradeoperation_list",
-                ),
-                path(
-                    "device/<uuid:pk>/firmware/",
-                    views.device_firmware_detail,
-                    name="api_devicefirmware_detail",
-                ),
-            ]
+
+def get_api_urls(api_views=views):
+    """
+    returns:: all the API urls of the firmware upgrader
+    """
+
+    def get_view(name):
+        """Fall back to the standard view when a custom view is unavailable."""
+        return getattr(api_views, name, getattr(views, name))
+
+    return [
+        path(
+            "firmware-upgrader/",
+            include(
+                [
+                    path("build/", get_view("build_list"), name="api_build_list"),
+                    path(
+                        "build/<uuid:pk>/",
+                        get_view("build_detail"),
+                        name="api_build_detail",
+                    ),
+                    path(
+                        "build/<uuid:pk>/upgrade/",
+                        get_view("api_batch_upgrade"),
+                        name="api_build_batch_upgrade",
+                    ),
+                    path(
+                        "build/<uuid:build_pk>/image/",
+                        get_view("firmware_image_list"),
+                        name="api_firmware_list",
+                    ),
+                    path(
+                        "build/<uuid:build_pk>/image/<uuid:pk>/",
+                        get_view("firmware_image_detail"),
+                        name="api_firmware_detail",
+                    ),
+                    path(
+                        "build/<uuid:build_pk>/image/<pk>/download/",
+                        get_view("firmware_image_download"),
+                        name="api_firmware_download",
+                    ),
+                    path(
+                        "category/", get_view("category_list"), name="api_category_list"
+                    ),
+                    path(
+                        "category/<uuid:pk>/",
+                        get_view("category_detail"),
+                        name="api_category_detail",
+                    ),
+                    path(
+                        "batch-upgrade-operation/",
+                        get_view("batch_upgrade_operation_list"),
+                        name="api_batchupgradeoperation_list",
+                    ),
+                    path(
+                        "batch-upgrade-operation/<uuid:pk>/",
+                        get_view("batch_upgrade_operation_detail"),
+                        name="api_batchupgradeoperation_detail",
+                    ),
+                    path(
+                        "upgrade-operation/",
+                        get_view("upgrade_operation_list"),
+                        name="api_upgradeoperation_list",
+                    ),
+                    path(
+                        "upgrade-operation/<uuid:pk>/",
+                        get_view("upgrade_operation_detail"),
+                        name="api_upgradeoperation_detail",
+                    ),
+                    path(
+                        "upgrade-operation/<uuid:pk>/cancel/",
+                        get_view("upgrade_operation_cancel"),
+                        name="api_upgradeoperation_cancel",
+                    ),
+                    path(
+                        "device/<uuid:pk>/upgrade-operation/",
+                        get_view("device_upgrade_operation_list"),
+                        name="api_deviceupgradeoperation_list",
+                    ),
+                    path(
+                        "device/<uuid:pk>/firmware/",
+                        get_view("device_firmware_detail"),
+                        name="api_devicefirmware_detail",
+                    ),
+                ]
+            ),
         ),
-    ),
-]
+    ]
+
+
+urlpatterns = get_api_urls()

--- a/openwisp_firmware_upgrader/tests/test_api_urls.py
+++ b/openwisp_firmware_upgrader/tests/test_api_urls.py
@@ -1,0 +1,82 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+from django.urls import reverse
+
+from openwisp_firmware_upgrader import settings as app_settings
+from openwisp_firmware_upgrader.api import views
+from openwisp_firmware_upgrader.api.urls import get_api_urls
+from openwisp_firmware_upgrader.urls import get_urls
+
+
+class TestApiUrls(SimpleTestCase):
+    def test_get_api_urls_uses_overrides_and_default_fallbacks(self):
+        def custom_view():
+            return None
+
+        view_names = {
+            "api_build_list": "build_list",
+            "api_build_detail": "build_detail",
+            "api_build_batch_upgrade": "api_batch_upgrade",
+            "api_firmware_list": "firmware_image_list",
+            "api_firmware_detail": "firmware_image_detail",
+            "api_firmware_download": "firmware_image_download",
+            "api_category_list": "category_list",
+            "api_category_detail": "category_detail",
+            "api_batchupgradeoperation_list": "batch_upgrade_operation_list",
+            "api_batchupgradeoperation_detail": "batch_upgrade_operation_detail",
+            "api_upgradeoperation_list": "upgrade_operation_list",
+            "api_upgradeoperation_detail": "upgrade_operation_detail",
+            "api_upgradeoperation_cancel": "upgrade_operation_cancel",
+            "api_deviceupgradeoperation_list": "device_upgrade_operation_list",
+            "api_devicefirmware_detail": "device_firmware_detail",
+        }
+        custom_views = SimpleNamespace(
+            **{
+                view_name: custom_view
+                for view_name in view_names.values()
+                if view_name != "device_firmware_detail"
+            }
+        )
+        callbacks = {
+            pattern.name: pattern.callback
+            for pattern in get_api_urls(custom_views)[0].url_patterns
+        }
+
+        for url_name, view_name in view_names.items():
+            with self.subTest(url_name=url_name):
+                expected = (
+                    views.device_firmware_detail
+                    if view_name == "device_firmware_detail"
+                    else custom_view
+                )
+                self.assertIs(callbacks[url_name], expected)
+
+        default_callbacks = {
+            pattern.name: pattern.callback for pattern in get_api_urls()[0].url_patterns
+        }
+
+        for url_name, view_name in view_names.items():
+            with self.subTest(url_name=url_name, custom=False):
+                self.assertIs(default_callbacks[url_name], getattr(views, view_name))
+
+
+class TestUrls(SimpleTestCase):
+    def test_get_urls_includes_private_storage_and_api_urls(self):
+        urlpatterns = get_urls()
+        self.assertEqual(len(urlpatterns), 2)
+        self.assertEqual(urlpatterns[0].url_patterns[0].name, "serve_private_file")
+        api_pattern = urlpatterns[1]
+        self.assertEqual(api_pattern.pattern._route, "api/v1/")
+        self.assertEqual(api_pattern.namespace, "upgrader")
+        self.assertEqual(
+            reverse("upgrader:api_build_list"),
+            "/api/v1/firmware-upgrader/build/",
+        )
+
+    def test_get_urls_with_api_disabled(self):
+        with patch.object(app_settings, "FIRMWARE_UPGRADER_API", False):
+            urlpatterns = get_urls()
+        self.assertEqual(len(urlpatterns), 1)
+        self.assertEqual(urlpatterns[0].url_patterns[0].name, "serve_private_file")

--- a/openwisp_firmware_upgrader/tests/test_api_urls.py
+++ b/openwisp_firmware_upgrader/tests/test_api_urls.py
@@ -75,6 +75,18 @@ class TestUrls(SimpleTestCase):
             "/api/v1/firmware-upgrader/build/",
         )
 
+    def test_get_urls_uses_overrides_and_default_fallbacks(self):
+        def custom_view():
+            return None
+
+        custom_views = SimpleNamespace(build_list=custom_view)
+        callbacks = {
+            pattern.name: pattern.callback
+            for pattern in get_urls(custom_views)[1].url_patterns[0].url_patterns
+        }
+        self.assertIs(callbacks["api_build_list"], custom_view)
+        self.assertIs(callbacks["api_firmware_list"], views.firmware_image_list)
+
     def test_get_urls_with_api_disabled(self):
         with patch.object(app_settings, "FIRMWARE_UPGRADER_API", False):
             urlpatterns = get_urls()

--- a/openwisp_firmware_upgrader/urls.py
+++ b/openwisp_firmware_upgrader/urls.py
@@ -1,12 +1,22 @@
 from django.urls import include, path
 
 from openwisp_firmware_upgrader import settings as app_settings
+from openwisp_firmware_upgrader.api import views as api_views
+from openwisp_firmware_upgrader.api.urls import get_api_urls
 
-urlpatterns = [
-    path("", include("openwisp_firmware_upgrader.private_storage.urls")),
-]
 
-if app_settings.FIRMWARE_UPGRADER_API:
-    urlpatterns += [
-        path("api/v1/", include("openwisp_firmware_upgrader.api.urls")),
+def get_urls(api_views=api_views):
+    urlpatterns = [
+        path("", include("openwisp_firmware_upgrader.private_storage.urls")),
     ]
+    if app_settings.FIRMWARE_UPGRADER_API:
+        urlpatterns += [
+            path(
+                "api/v1/",
+                include((get_api_urls(api_views), "upgrader"), namespace="upgrader"),
+            ),
+        ]
+    return urlpatterns
+
+
+urlpatterns = get_urls()


### PR DESCRIPTION
## Checklist
- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #472 .

## Description of Changes

- Added `get_view()` functions to the respective `urls.py` files to mimic the work done in openwisp-users and openwisp-ipam.
- Updated the docs with instructions and example on how to use the `get_view()` function.  
- Added tests regarding `get_view()` function

## Screenshot
N/A
